### PR TITLE
Adding oommf.cyg for Zeus installation

### DIFF
--- a/sles11sp4/oommf.cyg
+++ b/sles11sp4/oommf.cyg
@@ -1,0 +1,39 @@
+##############################################################################
+# maali cygnet file for OOMMF (tested with version 12a6_20150930)
+##############################################################################
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_GCC_COMPILERS"
+# URL to download the source code from
+MAALI_URL="http://math.nist.gov/oommf/dist/${MAALI_TOOL_NAME}${MAALI_TOOL_VERSION}.tar.gz"
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME$MAALI_TOOL_VERSION.tar.gz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME/"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="apps"
+
+# tool pre-requisites 
+MAALI_TOOL_PREREQ=""
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE="" 
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_WHATIS="OMMF (Object Oriented MicroMagnetic Framework) project"
+
+##############################################################################
+
+function maali_build {
+  maali_run  "cp -R $MAALI_TOOL_BUILD_DIR/* $MAALI_INSTALL_DIR"
+  cd "$MAALI_INSTALL_DIR"
+  maali_run "sed -i 's/# \$config SetValue oommf_threads 0/ \$config SetValue oommf_threads 1/g' ./config/platforms/linux-x86_64.tcl"
+  maali_run "tclsh oommf.tcl pimake distclean"
+  maali_run "tclsh oommf.tcl pimake"
+}
+
+##############################################################################


### PR DESCRIPTION
Added a file for future refer for installing a TCL script based installation of oommf. This cygnet file is for Zeus only. 