### PR TITLE
Amended casacore.cyg to add URL for Versions 2.0 and onwards

### DIFF
--- a/cle52up04/casacore.cyg
+++ b/cle52up04/casacore.cyg
@@ -12,8 +12,11 @@ MAALI_TOOL_CRAY_CPU_TARGET="$MAALI_DEFAULT_CRAY_PES"
 MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
 
 # URL to download the source code from
+if (( $(bc <<< "${MAALI_TOOL_MAJOR_MINOR_VERSION} < 2.0") )); then
 MAALI_URL="ftp://ftp.atnf.csiro.au/pub/software/$MAALI_TOOL_NAME/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.bz2"
-
+elif (( $(bc <<< "${MAALI_TOOL_MAJOR_MINOR_VERSION} >= 2.0") )); then
+MAALI_URL="https://github.com/${MAALI_TOOL_NAME}/${MAALI_TOOL_NAME}/archive/v${MAALI_TOOL_VERSION}.tar.gz"
+fi
 # location we are downloading the source code to
 MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.bz2"
 


### PR DESCRIPTION
Hi, 
I have updated casacore.cyg so that it can download Versions 2.0 and greater from github repo. 
The rest of the script is the same. 
Regards
Mohsin.