### PR TITLE
cygnet files for netcdf4-python, pixman, cairo, and NCL

### DIFF
--- a/cle52up04/netcdf4-python.cyg
+++ b/cle52up04/netcdf4-python.cyg
@@ -1,0 +1,47 @@
+##############################################################################
+# maali cygnet file for netcdf4-python 
+##############################################################################
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_PYTHON"
+
+# URL to download the source code from
+MAALI_URL="https://github.com/Unidata/netcdf4-python.git"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/netcdf4-python"
+
+# tool pre-requisites
+MAALI_TOOL_PREREQ="python/2.7.10 PrgEnv-gnu/5.2.82 gcc/4.8.2 numpy/1.10.1 cython/0.23.4 cray-netcdf/4.3.2"
+
+# tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
+MAALI_TOOL_BUILD_PREREQ=""
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+
+##############################################################################
+function maali_download {
+  cd $MAALI_SRC
+  git clone $MAALI_URL
+}
+
+function maali_unpack {
+  cd $MAALI_BUILD_DIR
+  
+  cp -r $MAALI_DST .
+}
+
+function maali_python_build {
+
+cd $MAALI_TOOL_BUILD_DIR
+
+maali_run "python setup.py build"
+maali_run "python setup.py install --prefix=$MAALI_INSTALL_DIR"
+
+}
+
+##############################################################################

--- a/sles11sp4/cairo.cyg
+++ b/sles11sp4/cairo.cyg
@@ -1,0 +1,34 @@
+##############################################################################
+# maali cygnet file for cairo
+##############################################################################
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_SYSTEM_GCC"
+
+# URL to download the source code from
+MAALI_URL="http://cairographics.org/releases/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.xz"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.xz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# tool pre-requisites
+MAALI_TOOL_PREREQ="pixman/0.32.8"
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE=''
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_PKG_CONFIG_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_FPATH=1
+MAALI_MODULE_SET_FCPATH=1
+
+##############################################################################

--- a/sles11sp4/ncl.cyg
+++ b/sles11sp4/ncl.cyg
@@ -1,0 +1,94 @@
+##############################################################################
+# maali config file for ncl and ncarg - note you need to download source manually
+# from http://www.ncl.ucar.edu/Download/ and place in the MAALI_BUILD_DIR 
+##############################################################################
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_GCC_COMPILERS"
+
+# URL to download the source code from
+#MAALI_URL=""
+# use the script NCL.download.script in $MAALI_SRC to download 
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/${MAALI_TOOL_NAME}_ncarg-${MAALI_TOOL_VERSION}.tar.gz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/${MAALI_TOOL_NAME}_ncarg-${MAALI_TOOL_VERSION}"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="apps"
+
+# tool pre-requisites
+MAALI_TOOL_PREREQ="zlib/1.2.8 szip/2.1 hdf4/4.2.11 hdf5/1.8.15-patch1 netcdf/4.1.3 cairo/1.14.6"
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE=''
+
+# runs in front of the configure line
+export CFLAGS=""
+
+# defined environment variable of the basic path  
+#
+MAALI_MODULE_SET_SETENV='NCL_ROOT$MAALI_APP_HOME NCARG_ROOT=$MAALI_APP_HOME'
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_MANPATH=1
+
+##############################################################################
+
+function maali_build {
+
+  cd $MAALI_TOOL_BUILD_DIR
+
+  # create configure input file
+  CONFIG_INPUT_FILE=$MAALI_TOOL_BUILD_DIR/input.txt
+cat << EOF > "$CONFIG_INPUT_FILE" 
+
+
+y
+$MAALI_INSTALL_DIR
+
+y
+n
+n
+n
+y
+n
+n
+n
+n
+n
+n
+n
+n
+/usr/lib64
+/usr/include /usr/include/freetype2
+n
+y
+EOF
+
+
+  # run configure script
+  maali_run "cat $CONFIG_INPUT_FILE | ./Configure -v"
+
+  sed -i "s/#define LibSearch -L\/usr\/lib64/#define LibSearch -L$\{MAALI\_HDF5\_HOME\}\/lib -L$\{MAALI\_SZIP\_HOME\}\/lib -L$\{MAALI\_ZLIB\_HOME\}\/lib -L$\{MAALI\_NETCDF\_HOME\}\/lib -L$\{MAALI\_UDUNITS\_HOME\}\/lib -L$\{MAALI\_CAIRO\_HOME\}\/lib -L$\{MAALI\_PIXMAN\_HOME\}\/lib -L\/usr\/lib64 /g" ./config/Site.local
+
+  sed -i "s/-I\/usr\/include\/freetype2/-I\/usr\/include\/freetype2 -I$\{MAALI\_CAIRO\_HOME\}\/include -I$\{MAALI\_PIXMAN\_HOME\}\/include -I$\{MAALI\_NETCDF\_HOME\}\/include -I$\{MAALI\_HDF5\_HOME\}\/include -I$\{MAALI\_UDUNITS\_HOME\}\/include -I$\{MAALI\_ZLIB\_HOME\}\/include -I$\{MAALI\_SZIP\_HOME\}\/include/g" ./config/Site.local
+
+
+  # make
+  maali_run "make Everything >& make-output"
+
+  sed -i "s/set cairolib = \"-lcairo -lfontconfig -lpixman-1/set cairolib = \"-L$\{MAALI\_CAIRO\_HOME\}\/lib -lcairo -lfontconfig -L$\{MAALI\_PIXMAN\_HOME\}\/lib -lpixman-1/g" $MAALI_INSTALL_DIR/bin/ncargcc
+  sed -i "s/set cairolib = \"-lcairo -lfontconfig -lpixman-1/set cairolib = \"-L$\{MAALI\_CAIRO\_HOME\}\/lib -lcairo -lfontconfig -L$\{MAALI\_PIXMAN\_HOME\}\/lib -lpixman-1/g" $MAALI_INSTALL_DIR/bin/ncargf77
+  sed -i "s/set cairolib = \"-lcairo -lfontconfig -lpixman-1/set cairolib = \"-L$\{MAALI\_CAIRO\_HOME\}\/lib -lcairo -lfontconfig -L$\{MAALI\_PIXMAN\_HOME\}\/lib -lpixman-1/g" $MAALI_INSTALL_DIR/bin/ncargf90
+  sed -i "s/set cairolib = \"-lcairo -lfontconfig -lpixman-1/set cairolib = \"-L$\{MAALI\_CAIRO\_HOME\}\/lib -lcairo -lfontconfig -L$\{MAALI\_PIXMAN\_HOME\}\/lib -lpixman-1/g" $MAALI_INSTALL_DIR/bin/nhlcc
+  sed -i "s/set cairolib = \"-lcairo -lfontconfig -lpixman-1/set cairolib = \"-L$\{MAALI\_CAIRO\_HOME\}\/lib -lcairo -lfontconfig -L$\{MAALI\_PIXMAN\_HOME\}\/lib -lpixman-1/g" $MAALI_INSTALL_DIR/bin/nhlf77
+  sed -i "s/set cairolib = \"-lcairo -lfontconfig -lpixman-1/set cairolib = \"-L$\{MAALI\_CAIRO\_HOME\}\/lib -lcairo -lfontconfig -L$\{MAALI\_PIXMAN\_HOME\}\/lib -lpixman-1/g" $MAALI_INSTALL_DIR/bin/nhlf90
+
+
+}
+
+##############################################################################

--- a/sles11sp4/pixman.cyg
+++ b/sles11sp4/pixman.cyg
@@ -1,0 +1,31 @@
+##############################################################################
+# maali cygnet file for pixman
+##############################################################################
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_SYSTEM_GCC"
+
+# URL to download the source code from
+MAALI_URL="http://cairographics.org/releases/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE=''
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_PKG_CONFIG_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_FPATH=1
+MAALI_MODULE_SET_FCPATH=1
+
+##############################################################################


### PR DESCRIPTION
new cygnet file for netcdf4-python on cle52;
copied pixman and cairo cygnet files on cle52 to sles11;
new cygnet file for NCAR command language on sles11. 