### PR TITLE
Adding OpenFOAM build recipe for ESI's OpenFOAM+ versions. 

### DIFF
--- a/cle52up04/cgal.cyg
+++ b/cle52up04/cgal.cyg
@@ -1,0 +1,38 @@
+##############################################################################
+# maali cygnet file for cgal tested version 4.8
+##############################################################################
+
+# specify which PrgEnv we want to build the tool with
+MAALI_TOOL_CRAY_PRGENV="$MAALI_DEFAULT_CRAY_GCC_PRGENV"
+
+# specify which cpus to target
+MAALI_TOOL_CRAY_CPU_TARGET="$MAALI_DEFAULT_CRAY_PES"
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+
+# URL to download the source code from
+MAALI_URL="https://github.com/CGAL/cgal/archive/releases/CGAL-${MAALI_TOOL_VERSION}.tar.gz"
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/CGAL-$MAALI_TOOL_VERSION"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/cgal-releases-CGAL-$MAALI_TOOL_VERSION"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="apps"
+
+# tool pre-requisites 
+MAALI_TOOL_PREREQ="boost/1.57.0"
+#
+# add additional configure options
+MAALI_TOOL_CONFIGURE="" 
+
+# tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
+MAALI_TOOL_BUILD_PREREQ="cmake/2.8.12.2"
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_WHATIS="CGAL is a software project that provides easy access to efficient and reliable geometric algorithms in the form of a C++ library. CGAL is used in various areas needing geometric computation, such as geographic information systems, computer aided design, molecular biology, medical imaging, computer graphics, and robotics."
+##############################################################################

--- a/cle52up04/jive5ab.cyg
+++ b/cle52up04/jive5ab.cyg
@@ -1,0 +1,47 @@
+#################################################################################
+# maali cygnet file for jive5ab
+#################################################################################
+
+# specify which PrgEnv we want to build the tool with
+MAALI_TOOL_CRAY_PRGENV="$MAALI_DEFAULT_CRAY_GCC_PRGENV"
+
+# specify which cpus to target
+MAALI_TOOL_CRAY_CPU_TARGET="$MAALI_DEFAULT_CRAY_PES"
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+
+MAALI_URL="http://www.jive.nl/~verkout/evlbi/${MAALI_TOOL_NAME}-${MAALI_TOOL_VERSION}.tar.gz"
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-v${MAALI_TOOL_VERSION}.tar.gz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/${MAALI_TOOL_NAME}-${MAALI_TOOL_VERSION}"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="apps"
+
+# tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
+MAALI_TOOL_BUILD_PREREQ=""
+
+# tool pre-requisites 
+MAALI_TOOL_PREREQ="$MAALI_DEFAULT_MPI"
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE=""
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_WHATIS=""
+
+##############################################################################
+
+function maali_build {
+  cd "$MAALI_TOOL_BUILD_DIR"
+  
+  maali_run "make -j 8 B2B=64"
+  
+  cp jive5ab $MAALI_INSTALL_DIR/bin
+}
+
+##############################################################################

--- a/cle52up04/openfoam-esi.cyg
+++ b/cle52up04/openfoam-esi.cyg
@@ -1,0 +1,286 @@
+##############################################################################
+# maali cygnet file for OpenFOAM
+##############################################################################
+
+# specify which PrgEnv we want to build the tool with
+MAALI_TOOL_CRAY_PRGENV="$MAALI_DEFAULT_CRAY_GCC_PRGENV"
+
+# specify which cpus to target
+MAALI_TOOL_CRAY_CPU_TARGET="haswell"
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="gcc/4.8.2"
+
+# URL to download the source code from
+MAALI_URL="https://sourceforge.net/projects/openfoamplus/files/${MAALI_TOOL_VERSION}/OpenFOAM-${MAALI_TOOL_VERSION}.tgz;https://sourceforge.net/projects/openfoamplus/files/${MAALI_TOOL_VERSION}/ThirdParty-${MAALI_TOOL_VERSION}.tgz"
+
+# location we are downloading the source code to
+#MAALI_DST="$MAALI_SRC/OpenFOAM-$MAALI_TOOL_VERSION.tgz $MAALI_SRC/ThirdParty-$MAALI_TOOL_VERSION.tgz"
+
+# where the unpacked source code is located - OpenFOAM builds in place
+MAALI_TOOL_BUILD_DIR=""
+
+# tool pre-requisites
+MAALI_TOOL_PREREQ="$MAALI_DEFAULT_MPI cray-libsci slurm alps boost/1.57.0 cgal/4.8.2"
+
+# for auto-building module files
+MAALI_MODULE_WHATIS="Provides the environment for the CFD package OpenFOAM."
+# order is important
+MAALI_MODULE_VARIABLES_ORDER="MAALI_MODULE_SET_foam_COMPILER MAALI_MODULE_SET_HDF5_DIR MAALI_MODULE_SET_FOAM_INST_DIR MAALI_MODULE_SET_WM_PROJECT MAALI_MODULE_SET_WM_PROJECT_VERSION MAALI_MODULE_SET_WM_COMPILER MAALI_MODULE_SET_WM_ARCH_OPTION MAALI_MODULE_SET_WM_PRECISION_OPTION MAALI_MODULE_SET_WM_LABEL_SIZE MAALI_MODULE_SET_WM_COMPILE_OPTION MAALI_MODULE_SET_WM_MPLIB MAALI_MODULE_SET_WM_OSTYPE MAALI_MODULE_SET_FOAM_SIGFPE MAALI_MODULE_SET_WM_PROJECT_INST_DIR MAALI_MODULE_SET_WM_PROJECT_DIR MAALI_MODULE_SET_WM_THIRD_PARTY_DIR MAALI_MODULE_SET_WM_PROJECT_USER_DIR MAALI_MODULE_SET_FOAM_SETTINGS MAALI_MODULE_SET_WM_ARCH MAALI_MODULE_SET_WM_COMPILER_LIB_ARCH MAALI_MODULE_SET_WM_CC MAALI_MODULE_SET_WM_CXX MAALI_MODULE_SET_WM_CFLAGS MAALI_MODULE_SET_WM_CXXFLAGS MAALI_MODULE_SET_WM_LDFLAGS MAALI_MODULE_SET_FOAM_JOB_DIR MAALI_MODULE_SET_WM_DIR MAALI_MODULE_SET_WM_LINK_LANGUAGE MAALI_MODULE_SET_WM_LABEL_OPTION MAALI_MODULE_SET_WM_OPTIONS MAALI_MODULE_SET_FOAM_APPBIN MAALI_MODULE_SET_FOAM_LIBBIN MAALI_MODULE_SET_FOAM_EXT_LIBBIN MAALI_MODULE_SET_FOAM_SITE_APPBIN MAALI_MODULE_SET_FOAM_SITE_LIBBIN MAALI_MODULE_SET_FOAM_USER_APPBIN MAALI_MODULE_SET_FOAM_USER_LIBBIN MAALI_MODULE_SET_FOAM_ETC MAALI_MODULE_SET_FOAM_APP MAALI_MODULE_SET_FOAM_SRC MAALI_MODULE_SET_FOAM_TUTORIALS MAALI_MODULE_SET_FOAM_UTILITIES MAALI_MODULE_SET_FOAM_SOLVERS MAALI_MODULE_SET_FOAM_RUN MAALI_MODULE_SET_FOAM_MPI MAALI_MODULE_SET_FOAM_MPI_LIBBIN MAALI_MODULE_SET_MPI_ARCH_PATH MAALI_MODULE_SET_MPI_BUFFER_SIZE MAALI_MODULE_SET_ParaView_DIR MAALI_MODULE_SET_ParaView_LIB_DIR MAALI_MODULE_SET_ParaView_INCLUDE_DIR MAALI_MODULE_SET_PV_PLUGIN_PATH MAALI_MODULE_SET_CGAL_ARCH_PATH MAALI_MODULE_SET_PATH MAALI_MODULE_SET_LD_LIBRARY_PATH MAALI_MODULE_SET_LD_LIBRARY_PATH_APPEND"
+MAALI_MODULE_SET_foam_COMPILER='Gcc'
+MAALI_MODULE_SET_HDF5_DIR='$MAALI_APP_HOME'
+MAALI_MODULE_SET_FOAM_INST_DIR='$MAALI_APP_HOME'
+MAALI_MODULE_SET_WM_PROJECT='OpenFOAM'
+MAALI_MODULE_SET_WM_PROJECT_VERSION='$MAALI_TOOL_VERSION'
+MAALI_MODULE_SET_WM_COMPILER='\$env\(foam_COMPILER\)'
+MAALI_MODULE_SET_WM_ARCH_OPTION='cray'
+MAALI_MODULE_SET_WM_PRECISION_OPTION='DP'
+MAALI_MODULE_SET_WM_LABEL_SIZE='32'
+MAALI_MODULE_SET_WM_COMPILE_OPTION='Opt'
+MAALI_MODULE_SET_WM_MPLIB='MPICH2'
+MAALI_MODULE_SET_WM_OSTYPE='POSIX'
+MAALI_MODULE_SET_FOAM_SIGFPE=''
+MAALI_MODULE_SET_WM_PROJECT_INST_DIR='\$env\(FOAM_INST_DIR\)'
+MAALI_MODULE_SET_WM_PROJECT_DIR='\$env\(WM_PROJECT_INST_DIR\)/\$env\(WM_PROJECT\)-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_WM_THIRD_PARTY_DIR='\$env\(WM_PROJECT_INST_DIR\)/ThirdParty-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_WM_PROJECT_USER_DIR='\$env\(HOME\)/\$env\(WM_PROJECT\)/\$env\(USER\)-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_FOAM_SETTINGS=''
+MAALI_MODULE_SET_WM_ARCH='crayxc'
+MAALI_MODULE_SET_WM_COMPILER_LIB_ARCH='64'
+MAALI_MODULE_SET_WM_CC='cc'
+MAALI_MODULE_SET_WM_CXX='CC'
+MAALI_MODULE_SET_WM_CFLAGS='-O3 -fPIC'
+MAALI_MODULE_SET_WM_CXXFLAGS='-O3 -fPIC'
+MAALI_MODULE_SET_WM_LDFLAGS='-O3'
+MAALI_MODULE_SET_FOAM_JOB_DIR='\$env\(WM_PROJECT_INST_DIR\)/jobControl'
+MAALI_MODULE_SET_WM_DIR='\$env\(WM_PROJECT_DIR\)/wmake'
+MAALI_MODULE_SET_WM_LINK_LANGUAGE='c++'
+MAALI_MODULE_SET_WM_LABEL_OPTION='Int\$env\(WM_LABEL_SIZE\)'
+MAALI_MODULE_SET_WM_OPTIONS='\$env\(WM_ARCH\)\$env\(WM_COMPILER\)\$env\(WM_PRECISION_OPTION\)\$env\(WM_LABEL_OPTION\)\$env\(WM_COMPILE_OPTION\)'
+MAALI_MODULE_SET_FOAM_APPBIN='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/bin'
+MAALI_MODULE_SET_FOAM_LIBBIN='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_EXT_LIBBIN='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)\$env\(WM_PRECISION_OPTION\)\$env\(WM_LABEL_OPTION\)\$env\(WM_COMPILE_OPTION)/lib'
+MAALI_MODULE_SET_FOAM_SITE_APPBIN='\$env\(WM_PROJECT_INST_DIR\)/site/\$env\(WM_PROJECT_VERSION\)/platforms/\$env\(WM_OPTIONS\)/bin'
+MAALI_MODULE_SET_FOAM_SITE_LIBBIN='\$env\(WM_PROJECT_INST_DIR\)/site/\$env\(WM_PROJECT_VERSION\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_USER_APPBIN='\$env\(WM_PROJECT_USER_DIR\)/platforms/\$env\(WM_OPTIONS\)/bin'
+MAALI_MODULE_SET_FOAM_USER_LIBBIN='\$env\(WM_PROJECT_USER_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_ETC='\$env\(WM_PROJECT_DIR\)/etc'
+MAALI_MODULE_SET_FOAM_APP='\$env\(WM_PROJECT_DIR\)/applications'
+MAALI_MODULE_SET_FOAM_SRC='\$env\(WM_PROJECT_DIR\)/src'
+MAALI_MODULE_SET_FOAM_TUTORIALS='\$env\(WM_PROJECT_DIR\)/tutorials'
+MAALI_MODULE_SET_FOAM_UTILITIES='\$env\(FOAM_APP\)/utilities'
+MAALI_MODULE_SET_FOAM_SOLVERS='\$env\(FOAM_APP\)/solvers'
+MAALI_MODULE_SET_FOAM_RUN='\$env\(WM_PROJECT_USER_DIR\)/run'
+MAALI_MODULE_SET_FOAM_MPI='mpich2'
+MAALI_MODULE_SET_FOAM_MPI_LIBBIN='\$env\(FOAM_LIBBIN\)/\$env\(FOAM_MPI\)'
+MAALI_MODULE_SET_MPI_ARCH_PATH='\$env\(MPICH_DIR\)'
+MAALI_MODULE_SET_MPI_BUFFER_SIZE='20000000'
+MAALI_MODULE_SET_ParaView_DIR='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/ParaView-4.4.0'
+MAALI_MODULE_SET_ParaView_LIB_DIR='\$env\(ParaView_DIR\)/lib/paraview-4.4'
+MAALI_MODULE_SET_ParaView_INCLUDE_DIR='\$env\(ParaView_DIR\)/include/paraview-4.4'
+MAALI_MODULE_SET_PV_PLUGIN_PATH='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib/paraview-4.4'
+MAALI_MODULE_SET_BOOST_ARCH_PATH='\$env\(BOOST_ROOT\)'
+MAALI_MODULE_SET_CGAL_ARCH_PATH='\$env\(MAALI_CGAL_HOME\)'
+MAALI_MODULE_SET_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/gperftools-svn/bin \$env\(ParaView_DIR\)/bin \$env\(FOAM_USER_APPBIN\) \$env\(FOAM_SITE_APPBIN\) \$env\(FOAM_APPBIN\) \$env\(WM_PROJECT_DIR\)/bin \$env\(WM_DIR\)'
+MAALI_MODULE_SET_LD_LIBRARY_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/gperftools-svn/lib \$env\(CGAL_ARCH_PATH\)/lib \$env\(ParaView_LIB_DIR\) \$env\(FOAM_MPI_LIBBIN\) \$env\(FOAM_EXT_LIBBIN\)/\$env\(FOAM_MPI\) \$env\(FOAM_USER_LIBBIN\) \$env\(FOAM_SITE_LIBBIN\) \$env\(FOAM_LIBBIN\) \$env\(FOAM_EXT_LIBBIN\)'
+MAALI_MODULE_SET_LD_LIBRARY_PATH_APPEND='\$env\(FOAM_LIBBIN\)/dummy'
+# don't prepend the path with stuff
+MAALI_MODULE_PREPEND_PATH=off
+MAALI_MODULE_PREPEND_LD_LIBRARY_PATH=off
+MAALI_MODULE_PREPEND_LD_LIBRARY_PATH_APPEND=off
+# don't iterate through the setenv
+MAALI_MODULE_LIST_WM_CFLAGS=off
+MAALI_MODULE_LIST_WM_CXXFLAGS=off
+#############################################################################
+function maali_download {
+	maali_wiki "Downloading OpenFOAM-${MAALI_TOOL_VERSION} and ThridParty-${MAALI_TOOL_VERSION} from as tarball from openFOAM.com"
+	cd $MAALI_SRC
+	maali_run "wget --no-check-certificate https://sourceforge.net/projects/openfoamplus/files/${MAALI_TOOL_VERSION}/OpenFOAM-${MAALI_TOOL_VERSION}.tgz "
+	maali_run "wget --no-check-certificate https://sourceforge.net/projects/openfoamplus/files/${MAALI_TOOL_VERSION}/ThirdParty-${MAALI_TOOL_VERSION}.tgz"
+}
+function maali_unpack {
+	maali_wiki ".. Supressing untar as it will be run as part of the build"
+	
+}
+
+##############################################################################
+
+function maali_build {
+# OpenFOAM builds in place
+	maali_wiki ".. Building in $MAALI_INSTALL_DIR"
+
+	cd "$MAALI_INSTALL_DIR"
+	tar zxvf $MAALI_SRC/OpenFOAM-${MAALI_TOOL_VERSION}.tgz
+	tar zxvf $MAALI_SRC/ThirdParty-${MAALI_TOOL_VERSION}.tgz
+#	mv OpenFOAM-4.x-version-v1606+ OpenFOAM-v1606+ 
+#	mv ThirdParty-4.x-version-v1606+ ThirdParty-v1606+ 
+
+
+# Set OpenFOAM install dir
+		export FOAM_INST_DIR="$MAALI_INSTALL_DIR"
+
+# Set 4.x build specific env variables 
+		export SOURCE_CGAL_VERSIONS_ONLY=yes
+		export BOOST_ARCH_PATH=$BOOST_ROOT
+		export CGAL_ARCH_PATH=$MAALI_CGAL_HOME
+		export CRAYPE_LINK_TYPE=dynamic
+			
+maali_run "sed -i 's/boost_version=boost_1_61_0/boost_version=boost-system/g' $FOAM_INST_DIR/OpenFOAM-v1606+/etc/config.sh/CGAL"
+maali_run "sed -i 's/cgal_version=CGAL-4.8/cgal_version=cgal-system/g' $FOAM_INST_DIR/OpenFOAM-v1606+/etc/config.sh/CGAL"
+maali_run "sed -i 's/export\ BOOST_ARCH_PATH/#export\ BOOST_ARCH_PATH/g' $FOAM_INST_DIR/OpenFOAM-v1606+/etc/config.sh/CGAL" 
+maali_run "sed -i 's/export\ CGAL_ARCH_PATH/#export\ CGAL_ARCH_PATH/g' $FOAM_INST_DIR/OpenFOAM-v1606+/etc/config.sh/CGAL" 
+# Env. variables for building 
+		export WM_64=ON                  # 64-bit build
+		export WM_NCOMPPROCS=1           # Multi-core build
+
+# Include cray specific build environment in /etc/config.sh
+	maali_run "sed -i '/x86_64)/{N;s/$/\n\tcray)\n\texport WM_ARCH=crayxc\n\texport WM_COMPILER_LIB_ARCH=64\n\texport WM_CC='\'cc\''\n\texport WM_CXX='\'CC\''\n\texport WM_CFLAGS='\'-fPIC\''\n\texport WM_CXXFLAGS='\'-fPIC\''\n\t;;\n/}' $FOAM_INST_DIR/OpenFOAM-v1606+/etc/config.sh/settings"
+	maali_run "sed -i '/MPICH)/ i MPICH2)\n\texport FOAM_MPI=mpich2\n\texport FOAM_MPI_LIBBIN=\$FOAM_LIBBIN\/mpich2\n\texport MPI_ARCH_PATH=\$MPICH_DIR\n\t;;\n' $FOAM_INST_DIR/OpenFOAM-v1606+/etc/config.sh/mpi"
+# Write wmake rules for crayxc build
+	mkdir -p $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/c
+SUFFIXES += .c
+cWARN = -Wall
+cc = cc -m64
+include \$(DEFAULT_RULES)/c\$(WM_COMPILE_OPTION)
+cFLAGS = \$(GFLAGS) \$(cWARN) \$(cOPT) \$(cDBUG) \$(LIB_HEADER_DIRS) -fPIC -craype-verbose -g
+ctoo = \$(WM_SCHEDULER) \$(cc) \$(cFLAGS) -c \$< -o \$@
+LINK_LIBS = \$(cDBUG)
+LINKLIBSO   = \$(cc) -shared
+LINKEXE     = \$(cc) -Xlinker --add-needed -Xlinker -z -Xlinker nodefs
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/c++
+SUFFIXES += .C
+c++WARN = -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor -Wno-unused-parameter -Wno-invalid-offsetof
+# Suppress some warnings for flex++ and CGAL
+c++LESSWARN = -Wno-old-style-cast -Wno-unused-local-typedefs -Wno-array-bounds
+CC = CC -std=c++0x -m64
+include \$(DEFAULT_RULES)/c++\$(WM_COMPILE_OPTION) 
+ptFLAGS     = -DNoRepository -ftemplate-depth-100
+c++FLAGS    = \$(GFLAGS) \$(c++WARN) \$(c++OPT) \$(c++DBUG) \$(ptFLAGS) \$(LIB_HEADER_DIRS) -fPIC -g -craype-verbose
+Ctoo        = \$(WM_SCHEDULER) \$(CC) \$(c++FLAGS) -c \$< -o \$@
+cxxtoo      = \$(Ctoo)
+cctoo       = \$(Ctoo)
+cpptoo      = \$(Ctoo)
+LINK_LIBS   = \$(c++DBUG)
+LINKLIBSO   = \$(CC) \$(c++FLAGS) -shared -Xlinker --add-needed -Xlinker --no-as-needed
+LINKEXE     = \$(CC) \$(c++FLAGS) -Xlinker --add-needed -Xlinker --no-as-needed
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/cDebug
+cDBUG       = -ggdb -DFULLDEBUG
+cOPT        = -O1 -fdefault-inline -finline-functions
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/c++Debug
+c++DBUG = -ggdb3 -DFULLDEBUG
+c++OPT = -O0 -fdefault-inline
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/cOpt
+cDBUG =
+cOPT = -O3
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/c++Opt
+c++DBUG =
+c++OPT = -O3
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/cProf
+cDBUG = -pg
+cOPT = -O2
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/c++Prof
+c++DBUG = -pg
+c++OPT = -O2
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/general
+CPP        = cpp -traditional-cpp \$(GFLAGS)
+PROJECT_LIBS = -l\$(WM_PROJECT) -ldl
+include \$(GENERAL_RULES)/standard
+include \$(DEFAULT_RULES)/c
+include \$(DEFAULT_RULES)/c++
+EOF
+
+cat << EOF > $FOAM_INST_DIR/OpenFOAM-v1606+/wmake/rules/crayxcGcc/mplibMPICH2
+PFLAGS = -DMPICH_SKIP_MPICXX
+PINC =
+PLIBS =
+EOF
+
+# Modifying ThirdParty files
+cat << EOF > $FOAM_INST_DIR/ThirdParty-v1606+/etc/wmakeFiles/scotch/Makefile.inc.i686_pc_linux2.shlib-OpenFOAM-crayInt32
+EXE =
+LIB = .so
+OBJ = .o
+MAKE = make
+AR = cc -v
+ARFLAGS = -shared -o
+CAT = cat
+CCS = cc
+CCP = cc
+CCD = cc
+CFLAGS = -O3 -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -Drestrict=__restrict
+CLIBFLAGS = -shared -fPIC
+LDFLAGS = -lz -lm -lrt
+CP = cp
+LEX = flex -Pscotchyy -olex.yy.c
+LN = ln
+MKDIR = mkdir
+MV = mv
+RANLIB = echo
+YACC = bison -pscotchyy -y -b y
+EOF
+
+cat << EOF > $FOAM_INST_DIR/ThirdParty-v1606+/etc/wmakeFiles/scotch/Makefile.inc.i686_pc_linux2.shlib-OpenFOAM-crayInt64
+EXE =
+LIB = .so
+OBJ = .o
+MAKE = make
+AR = cc -v
+ARFLAGS = -shared -o
+CAT = cat
+CCS = cc
+CCP = cc
+CCD = cc
+CFLAGS = -O3 -DINTSIZE64 -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -Drestrict=__restrict
+CLIBFLAGS = -shared -fPIC
+LDFLAGS = -lz -lm -lrt
+CP = cp
+LEX = flex -Pscotchyy -olex.yy.c
+LN = ln
+MKDIR = mkdir
+MV = mv
+RANLIB = echo
+YACC = bison -pscotchyy -y -b y
+EOF
+# Modifying ThridParty scotch Makefile to run the unit test successfully on a compute node
+	maali_run "sed -i 's/\.\/dummysizes\$(EXE)/aprun\ -q\ \.\/dummysizes\$(EXE)/g' $FOAM_INST_DIR/ThirdParty-v1606+/scotch_6.0.3/src/libscotch/Makefile"
+	maali_run "sed -i 's/\.\/ptdummysizes\$(EXE)/aprun\ -q\ \.\/ptdummysizes\$(EXE)/g' $FOAM_INST_DIR/ThirdParty-v1606+/scotch_6.0.3/src/libscotch/Makefile"
+
+
+# Set up OpenFOAM environment
+		foamDotFile=$FOAM_INST_DIR/OpenFOAM-v1606+/etc/bashrc
+		maali_run "sed -i 's;FOAM_INST_DIR=\$HOME\/\$WM_PROJECT;FOAM_INST_DIR=${FOAM_INST_DIR}\/\$WM_PROJECT;g' $foamDotFile"
+		maali_run "sed -i 's;WM_ARCH_OPTION=64;WM_ARCH_OPTION=cray;g' $foamDotFile"
+		maali_run "sed -i 's;WM_MPLIB=SYSTEMOPENMPI;WM_MPLIB=MPICH2;g' $foamDotFile"
+		source $foamDotFile WM_LABEL_SIZE=32
+
+
+		cd $WM_PROJECT_DIR
+		maali_wiki "Changing directory to $WM_PROJECT_DIR"
+		maali_run "wclean"
+		maali_run "wcleanLnIncludeAll"
+		maali_run "wcleanPlatform"
+		maali_run "./Allwmake"
+
+# fix permissions
+ maali_run "find $MAALI_INSTALL_DIR -perm 750 -exec chmod 755 {} \;"
+ maali_run "find $MAALI_INSTALL_DIR -perm 640 -exec chmod 644 {} \;"
+}
+
+##############################################################################


### PR DESCRIPTION
Adding OpenFOAM build recipe for ESI's OpenFOAM+ versions. 
Tested with v1606+.
Requires cgal/4.8.x 
Added cgal.cyg for completeness