### PR TITLE
Mcheeseman knl fftw gsl

### DIFF
--- a/sles12sp2/fftw.cyg
+++ b/sles12sp2/fftw.cyg
@@ -14,7 +14,15 @@ For further information see http://www.fftw.org/
 EOF
 
 # specify which compilers we want to build the tool with
-MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+MAALI_TOOL_COMPILERS="gcc/6.3.0 intel/17.0.4"
+
+# specify the architectures we want to build the library on
+MAALI_TOOL_CPU_TARGET="knl broadwell"
+
+# tool pre-requisites modules needed to install this new tool/package
+if [[ $MAALI_TOOL_VERSION == "2."* ]]; then
+   MAALI_TOOL_PREREQ="mvapich"
+fi
 
 # URL to download the source code from
 MAALI_URL="http://www.fftw.org/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
@@ -27,13 +35,6 @@ MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
 
 # type of tool (eg. apps, devel, python, etc.)
 MAALI_TOOL_TYPE="devel"
-
-# add additional configure options
-MAALI_TOOL_CONFIGURE='--enable-threads --enable-shared --enable-sse2 --enable-avx --enable-avx2'
-
-# runs in front of the configure line
-export CFLAGS="-fPIC"
-export FFLAGS="-fPIC"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
@@ -50,25 +51,36 @@ MAALI_MODULE_SET_FFTW_LIB='$MAALI_APP_HOME/lib'
 ##############################################################################
 
 function maali_build {
-  # fftw needs a double build for creating software
-  #
-  if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
+  if [[ $MAALI_COMPILER_NAME == "intel"* ]]; then
+    export CC=icc
     export F77=ifort
+    if [[ $MAALI_CPU_NAME == "knl" ]]; then
+       export CFLAGS="-fPIC -xMIC-AVX512 -O3"
+       export FFLAGS="-fPIC -xMIC-AVX512 -O3"
+    else
+       export CFLAGS="-fPIC -xCORE-AVX2 -O3"
+       export FFLAGS="-fPIC -xCORE_AVX2 -O3"
+    fi
+  else
+    export CC=gcc
+    export F77=gfortran
+    if [[ $MAALI_CPU_NAME == "knl" ]]; then
+       export CFLAGS="-fPIC -mavx512f -mavx512cd -O2"
+       export FFLAGS="-fPIC -mavx512f -mavx512cd -O2"
+    else
+       export CFLAGS="-fPIC -mavx2 -O3"
+       export FFLAGS="-fPIC -mavx2 -O3"
+    fi
   fi
 
   cd "$MAALI_TOOL_BUILD_DIR"
-  # Making single precision version with type prefix
-  maali_run "./configure --prefix=$MAALI_INSTALL_DIR $MAALI_TOOL_CONFIGURE --enable-float --enable-type-prefix"
-  maali_run "make -j $MAALI_CORES"
-  maali_run "make install"
-  maali_run "make clean"
-  # Making double precision version without type prefix
-  maali_run "./configure --prefix=$MAALI_INSTALL_DIR $MAALI_TOOL_CONFIGURE"
-  maali_run "make -j $MAALI_CORES"
-  maali_run "make install"
-  maali_run "make clean"
-  # Making double precision version with type prefix
-  maali_run "./configure --prefix=$MAALI_INSTALL_DIR $MAALI_TOOL_CONFIGURE --enable-type-prefix"
+
+  if [[ $MAALI_TOOL_VERSION == "2."* ]]; then
+     maali_run "./configure --prefix=$MAALI_INSTALL_DIR --enable-mpi --enable-type-prefix --enable-double"
+  else
+     maali_run "./configure --prefix=$MAALI_INSTALL_DIR --enable-threads --enable-double"
+  fi
+
   maali_run "make -j $MAALI_CORES"
   maali_run "make install"
 }

--- a/sles12sp2/gsl.cyg
+++ b/sles12sp2/gsl.cyg
@@ -18,8 +18,14 @@ For further information see https://www.gnu.org/software/gsl/
 
 EOF
 
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="gcc/6.3.0 intel/17.0.4"
+
+# specify the architectures we want to build the library on
+MAALI_TOOL_CPU_TARGET="knl broadwell"
+
 # URL to download the source code from
-MAALI_URL="http://mirror.aarnet.edu.au/pub/gnu/gsl/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
+MAALI_URL="http://gnu.uberglobalmirror.com/$MAALI_TOOL_NAME/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
 
 # location we are downloading the source code to
 MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
@@ -28,13 +34,7 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
 
 # type of tool (eg. apps, devel, python, etc.)
-MAALI_TOOL_TYPE="devel"
-
-# used in the wiki navigation bar - defaults to MAALI_TOOL_NAME_ORIG
-MAALI_WIKI_TOOL_NAME="GSL"
-
-# for adding [[Category:Python]] to wiki page - bio-apps, devel and python automatically generate a category
-MAALI_WIKI_CATEGORY="Math Libraries"
+MAALI_TOOL_TYPE="apps"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
@@ -42,5 +42,32 @@ MAALI_MODULE_SET_LD_LIBRARY_PATH=1
 MAALI_MODULE_SET_CPATH=1
 MAALI_MODULE_SET_MANPATH=1
 MAALI_MODULE_SET_PKG_CONFIG_PATH=1
+
+##############################################################################
+
+function maali_build {
+  cd "$MAALI_TOOL_BUILD_DIR"
+
+  if [[ $MAALI_COMPILER_NAME == "intel"* ]]; then
+    export CC=icc
+    if [[ $MAALI_CPU_NAME == "knl" ]]; then
+       export CFLAGS="-xMIC-AVX512 -O3"
+    else
+       export CFLAGS="-xAVX2 -O3"
+    fi
+    maali_run "./configure --prefix=$MAALI_INSTALL_DIR"
+  else
+    export CC=gcc
+    if [[ $MAALI_CPU_NAME == "knl" ]]; then
+       export CFLAGS="-mavx512f -mavx512cd -O3"
+    else
+       export CFLAGS="-mavx2 -O3"
+    fi
+    maali_run "./configure --prefix=$MAALI_INSTALL_DIR --with-gnu-ld"
+  fi
+
+  maali_run "make -j $MAALI_CORES"
+  maali_run "make install"
+}
 
 ##############################################################################


### PR DESCRIPTION
Modified FFTW cygfile to distinguish between a FFTW-3 and FFTW-2 build.  KNL support added for both an Intel and GNU build.

Modified GSL cygfile to add KNL support.  Both Intel and GNU builds are defined 