### PR TITLE
update R cygnet file to point to new download URL. Intel support added

### DIFF
--- a/sles12sp2/r.cyg
+++ b/sles12sp2/r.cyg
@@ -16,19 +16,24 @@ For further information see https://www.r-project.org/about.html
 EOF
 
 # specify which compilers we want to build the tool with
-MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_GCC_COMPILERS"
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_GCC_COMPILERS $MAALI_DEFAULT_INTEL_COMPILERS"
+
+# specify the architectures we want to build the library on
+MAALI_TOOL_CPU_TARGET="sandybridge ivybridge broadwell"
 
 # URL to download the source code from
-MAALI_URL="http://cran.csiro.au/src/base/R-$MAALI_TOOL_MAJOR_VERSION/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
+if [[ $MAALI_TOOL_MAJOR_MINOR_VERSION == "3.2" ]]; then
+   MAALI_URL="http://cran.csiro.au/src/base/R-$MAALI_TOOL_MAJOR_VERSION/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
+else
+   MAALI_URL="https://cran.r-project.org/src/base/R-$MAALI_TOOL_MAJOR_VERSION/R-$MAALI_TOOL_VERSION.tar.gz"
+   MAALI_WGET_EXTRA=--no-check-certificate
+fi
 
 # location we are downloading the source code to
-MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
+MAALI_DST="$MAALI_SRC/R-$MAALI_TOOL_VERSION.tar.gz"
 
 # where the unpacked source code is located
-MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION"
-
-# packages that need to be installed in the operating system for this build to work
-#MAALI_SYSTEM_PACKAGES_PREREQ='cairo-devel libpng-devel libtiff-devel libjpeg-devel'
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/R-$MAALI_TOOL_VERSION"
 
 # add additional configure options
 MAALI_TOOL_CONFIGURE="--enable-R-shlib --with-x=no"


### PR DESCRIPTION
Added MAALI_URL to point to another R repository.  Current CSIRO address doesn't have the latest versions of R.