### PR TITLE
removed broadwell/1.0 module req. Added missing PrgEnv definition

### DIFF
--- a/cle60up05/mpi4py.cyg
+++ b/cle60up05/mpi4py.cyg
@@ -15,8 +15,10 @@ EOF
 # specify which compilers we want to build the tool with
 MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_PYTHON"
 
+MAALI_TOOL_CRAY_CPU_TARGET="sandybridge haswell"
+
 # URL to download the source code from
-MAALI_URL="https://files.pythonhosted.org/packages/source/$MAALI_PYTHON_FIRSTLETTER/$MAALI_TOOL_NAME_ORIG/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
+MAALI_URL="https://bitbucket.org/mpi4py/mpi4py/downloads/mpi4py-$MAALI_TOOL_VERSION.tar.gz"
 
 # location we are downloading the source code to
 MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
@@ -25,7 +27,7 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ="$MAALI_DEFAULT_SYSTEM_GCC broadwell/1.0 $MAALI_DEFAULT_MPI"
+MAALI_TOOL_PREREQ="$MAALI_DEFAULT_CRAY_GCC_PRGENV gcc/7.2.0 $MAALI_DEFAULT_MPI"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
@@ -33,7 +35,7 @@ MAALI_MODULE_SET_PATH=1
 ##############################################################################
 
 function maali_pre_build {
-  export CC=mpicc MPICC=mpicc
+  export CC=cc MPICC=cc
 }
 
 ##############################################################################


### PR DESCRIPTION
Added changes so that mpi4py will be built on the crays.  Previous cygnet file was more geared towards the generic x86 cluster platform.