### PR TITLE
Adding boost tested with version 1.64.0 with python support

### DIFF
--- a/cle60up05/boost.cyg
+++ b/cle60up05/boost.cyg
@@ -1,0 +1,70 @@
+##############################################################################
+# maali cygnet file for Boost
+##############################################################################
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+Boost provides free peer-reviewed portable C++ source libraries.
+
+Boost emphasizes libraries that work well with the C++ Standard Library. Boost
+libraries are intended to be widely useful, and usable across a broad spectrum
+of applications. The Boost license encourages both commercial and
+non-commercial use.
+
+For further information see http://www.boost.org/
+
+EOF
+
+# specify which PrgEnv we want to build the tool with
+MAALI_TOOL_CRAY_PRGENV="$MAALI_DEFAULT_CRAY_GCC_PRGENV $MAALI_DEFAULT_CRAY_INTEL_PRGENV"
+
+# specify which cpus to target
+MAALI_TOOL_CRAY_CPU_TARGET="$MAALI_DEFAULT_CRAY_PES"
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+
+# needed  for this URL
+MAALI_BOOST_VERSION=`echo $MAALI_TOOL_VERSION| sed -e 's/\./_/g'`
+
+# URL to download the source code from
+MAALI_URL="http://sourceforge.net/projects/$MAALI_TOOL_NAME/files/$MAALI_TOOL_NAME/$MAALI_TOOL_VERSION/${MAALI_TOOL_NAME}_${MAALI_BOOST_VERSION}.tar.gz/download"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/"$MAALI_TOOL_NAME"_"$MAALI_BOOST_VERSION".tar.gz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/"$MAALI_TOOL_NAME"_"$MAALI_BOOST_VERSION
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# tool pre-requisites
+MAALI_TOOL_PREREQ="python/2.7.14"
+
+# for auto-building module files
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_C_INCLUDE_PATH=1
+MAALI_MODULE_SET_CPLUS_INCLUDE_PATH=1
+MAALI_MODULE_SET_BOOST_ROOT='$MAALI_APP_HOME'
+
+##############################################################################
+
+function maali_build {
+
+  cd "$MAALI_TOOL_BUILD_DIR"
+  if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
+    # See https://software.intel.com/en-us/forums/intel-c-compiler/topic/516083
+    sed -i -e 's/!defined(__EDG_VERSION__)/!defined(__EDG_VERSION__) || defined(__INTEL_COMPILER)/g' boost/mpl/aux_/config/gcc.hpp
+
+    maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR --without-libraries=log --with-toolset=intel-linux"
+    maali_run "./bjam toolset=intel release"
+  else
+    maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR"
+    maali_run "./bjam -j 8 toolset=gcc release "
+  fi
+
+    maali_run "./bjam install --prefix=$MAALI_INSTALL_DIR"
+}
+
+##############################################################################


### PR DESCRIPTION
Will build boost/1.64.0 with both gcc and intel compilers on CLE6. 