### PR TITLE
Added updated OpenFOAM cygnet files

### DIFF
--- a/sles12sp3/openfoam+.cyg
+++ b/sles12sp3/openfoam+.cyg
@@ -1,0 +1,178 @@
+##############################################################################
+# maali cygnet file for OpenFOAM
+#
+# This is for the ESI version of OpenFOAM
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+OpenFOAM is an open-source CFD package, providing solvers, visualisation tools,
+and pre- and post-processing utilities.
+
+This module provides the ESI version of OpenFOAM
+
+For further information see http://openfoam.com
+
+EOF
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+MAALI_TOOL_CPU_TARGET="broadwell sandybridge"
+
+# URL to download the source code from
+MAALI_URL="https://sourceforge.net/projects/openfoamplus/files/$MAALI_TOOL_VERSION/OpenFOAM-$MAALI_TOOL_VERSION.tgz https://sourceforge.net/projects/openfoamplus/files/$MAALI_TOOL_VERSION/ThirdParty-$MAALI_TOOL_VERSION.tgz http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz https://cmake.org/files/v3.10/cmake-3.10.1.tar.gz"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/OpenFOAM-$MAALI_TOOL_VERSION.tar.gz $MAALI_SRC/ThirdParty-$MAALI_TOOL_VERSION.tar.gz $MAALI_SRC/metis-5.1.0.tar.gz $MAALI_SRC/cmake-3.10.1.tar.gz"
+
+# where the unpacked source code is located - OpenFOAM builds in place
+MAALI_TOOL_BUILD_DIR=""
+
+# tool pre-requisites
+MAALI_TOOL_PREREQ="$MAALI_DEFAULT_MPI python qt"
+
+# tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
+MAALI_TOOL_BUILD_PREREQ=""
+
+# for auto-building module files
+MAALI_MODULE_WHATIS="Provides the environment for the CFD package OpenFOAM."
+# order is important
+MAALI_MODULE_VARIABLES_ORDER="MAALI_MODULE_SET_foam_COMPILER MAALI_MODULE_SET_FOAM_INST_DIR MAALI_MODULE_SET_WM_PROJECT MAALI_MODULE_SET_WM_PROJECT_VERSION MAALI_MODULE_SET_WM_COMPILER MAALI_MODULE_SET_WM_COMPILER_TYPE MAALI_MODULE_SET_WM_ARCH_OPTION MAALI_MODULE_SET_WM_PRECISION_OPTION MAALI_MODULE_SET_WM_LABEL_SIZE MAALI_MODULE_SET_WM_COMPILE_OPTION MAALI_MODULE_SET_WM_MPLIB MAALI_MODULE_SET_WM_OSTYPE MAALI_MODULE_SET_WM_PROJECT_INST_DIR MAALI_MODULE_SET_WM_PROJECT_DIR MAALI_MODULE_SET_WM_THIRD_PARTY_DIR MAALI_MODULE_SET_WM_PROJECT_USER_DIR MAALI_MODULE_SET_FOAM_SETTINGS MAALI_MODULE_SET_WM_ARCH MAALI_MODULE_SET_WM_COMPILER_LIB_ARCH MAALI_MODULE_SET_WM_CC MAALI_MODULE_SET_WM_CXX MAALI_MODULE_SET_WM_CFLAGS MAALI_MODULE_SET_WM_CXXFLAGS MAALI_MODULE_SET_WM_LDFLAGS MAALI_MODULE_SET_WM_DIR MAALI_MODULE_SET_WM_LINK_LANGUAGE MAALI_MODULE_SET_WM_LABEL_OPTION MAALI_MODULE_SET_WM_OPTIONS MAALI_MODULE_SET_FOAM_ETC MAALI_MODULE_SET_FOAM_APPBIN MAALI_MODULE_SET_FOAM_LIBBIN MAALI_MODULE_SET_FOAM_EXT_LIBBIN MAALI_MODULE_SET_FOAM_SITE_APPBIN MAALI_MODULE_SET_FOAM_SITE_LIBBIN MAALI_MODULE_SET_FOAM_USER_APPBIN MAALI_MODULE_SET_FOAM_USER_LIBBIN MAALI_MODULE_SET_FOAM_APP MAALI_MODULE_SET_FOAM_SRC MAALI_MODULE_SET_FOAM_TUTORIALS MAALI_MODULE_SET_FOAM_UTILITIES MAALI_MODULE_SET_FOAM_SOLVERS MAALI_MODULE_SET_FOAM_RUN MAALI_MODULE_SET_FOAM_MPI MAALI_MODULE_SET_MPI_ARCH_PATH MAALI_MODULE_SET_ParaView_VERSION MAALI_MODULE_SET_ParaView_MAJOR MAALI_MODULE_SET_ParaView_DIR MAALI_MODULE_SET_ParaView_LIB_DIR MAALI_MODULE_SET_ParaView_INCLUDE_DIR MAALI_MODULE_SET_PV_PLUGIN_PATH MAALI_MODULE_SET_CGAL_ARCH_PATH MAALI_MODULE_SET_PATH MAALI_MODULE_SET_LD_LIBRARY_PATH MAALI_MODULE_SET_LD_LIBRARY_PATH_APPEND"
+MAALI_MODULE_SET_WM_CFLAGS='-m64 -fPIC'
+MAALI_MODULE_SET_WM_CXXFLAGS='-m64 -fPIC -std=c++0x'
+MAALI_MODULE_SET_WM_LDFLAGS='-m64'
+MAALI_MODULE_SET_FOAM_INST_DIR='$MAALI_APP_HOME'
+MAALI_MODULE_SET_WM_PROJECT='OpenFOAM'
+MAALI_MODULE_SET_WM_PROJECT_VERSION='$MAALI_TOOL_VERSION'
+MAALI_MODULE_SET_WM_COMPILER='\$env\(foam_COMPILER\)'
+MAALI_MODULE_SET_WM_COMPILER_TYPE=system
+MAALI_MODULE_SET_WM_ARCH_OPTION='64'
+MAALI_MODULE_SET_WM_PRECISION_OPTION='DP'
+MAALI_MODULE_SET_WM_LABEL_SIZE='32'
+MAALI_MODULE_SET_WM_COMPILE_OPTION='Opt'
+MAALI_MODULE_SET_WM_MPLIB='SYSTEMOPENMPI'
+MAALI_MODULE_SET_WM_OSTYPE='POSIX'
+MAALI_MODULE_SET_WM_PROJECT_INST_DIR='\$env\(FOAM_INST_DIR\)'
+MAALI_MODULE_SET_WM_PROJECT_DIR='\$env\(WM_PROJECT_INST_DIR\)/\$env\(WM_PROJECT\)-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_WM_THIRD_PARTY_DIR='\$env\(WM_PROJECT_INST_DIR\)/ThirdParty-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_WM_PROJECT_USER_DIR='\$env\(MYGROUP\)/\$env\(WM_PROJECT\)/\$env\(USER\)-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_FOAM_SETTINGS=''
+MAALI_MODULE_SET_WM_ARCH='linux64'
+MAALI_MODULE_SET_WM_COMPILER_LIB_ARCH='64'
+MAALI_MODULE_SET_WM_CC='mpicc'
+MAALI_MODULE_SET_WM_CXX='mpicxx'
+MAALI_MODULE_SET_WM_DIR='\$env\(WM_PROJECT_DIR\)/wmake'
+MAALI_MODULE_SET_WM_LINK_LANGUAGE='c++'
+MAALI_MODULE_SET_WM_LABEL_OPTION='Int\$env\(WM_LABEL_SIZE\)'
+MAALI_MODULE_SET_WM_OPTIONS='\$env\(WM_ARCH\)\$env\(WM_COMPILER\)\$env\(WM_PRECISION_OPTION\)\$env\(WM_LABEL_OPTION\)\$env\(WM_COMPILE_OPTION\)'
+MAALI_MODULE_SET_FOAM_APPBIN='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/bin'
+MAALI_MODULE_SET_FOAM_LIBBIN='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_EXT_LIBBIN='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_SITE_APPBIN='\$env\(WM_PROJECT_INST_DIR\)/site/\$env\(WM_PROJECT_VERSION\)/platforms/\$env\(WM_OPTIONS\)/bin'
+MAALI_MODULE_SET_FOAM_SITE_LIBBIN='\$env\(WM_PROJECT_INST_DIR\)/site/\$env\(WM_PROJECT_VERSION\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_USER_APPBIN='\$env\(WM_PROJECT_USER_DIR\)/platforms/\$env\(WM_OPTIONS\)/bin'
+MAALI_MODULE_SET_FOAM_USER_LIBBIN='\$env\(WM_PROJECT_USER_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
+MAALI_MODULE_SET_FOAM_ETC='\$env\(WM_PROJECT_DIR\)/etc'
+MAALI_MODULE_SET_FOAM_APP='\$env\(WM_PROJECT_DIR\)/applications'
+MAALI_MODULE_SET_FOAM_SRC='\$env\(WM_PROJECT_DIR\)/src'
+MAALI_MODULE_SET_FOAM_TUTORIALS='\$env\(WM_PROJECT_DIR\)/tutorials'
+MAALI_MODULE_SET_FOAM_UTILITIES='\$env\(FOAM_APP\)/utilities'
+MAALI_MODULE_SET_FOAM_SOLVERS='\$env\(FOAM_APP\)/solvers'
+MAALI_MODULE_SET_FOAM_RUN='\$env\(WM_PROJECT_USER_DIR\)/run'
+MAALI_MODULE_SET_FOAM_MPI='openmpi-system'
+MAALI_MODULE_SET_FOAM_FILEHANDLER='collated'
+MAALI_MODULE_SET_MPI_ARCH_PATH='\$env\(MAALI_OPENMPI_HOME\)'
+MAALI_MODULE_SET_ParaView_VERSION='5.4.0'
+MAALI_MODULE_SET_ParaView_MAJOR='5.4'
+MAALI_MODULE_SET_ParaView_DIR='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/ParaView-\$env\(ParaView_VERSION\)'
+MAALI_MODULE_SET_ParaView_LIB_DIR='\$env\(ParaView_DIR\)/lib/paraview-\$env\(ParaView_MAJOR\)'
+MAALI_MODULE_SET_ParaView_INCLUDE_DIR='\$env\(ParaView_DIR\)/include/paraview-\$env\(ParaView_MAJOR\)'
+MAALI_MODULE_SET_PV_PLUGIN_PATH='\$env\(FOAM_LIBBIN\)/paraview-\$env\(ParaView_MAJOR\)'
+MAALI_MODULE_SET_BOOST_ARCH_PATH='\$env\(MAALI_BOOST_HOME\)'
+MAALI_MODULE_SET_ParaView_DIR='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/ParaView-\$env\(ParaView_VERSION\)'
+MAALI_MODULE_SET_CGAL_ARCH_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)/$env\(WM_COMPILER\)/CGAL-4.8.1'
+MAALI_MODULE_SET_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/gperftools-svn/bin \$env\(ParaView_DIR\)/bin \$env\(FOAM_USER_APPBIN\) \$env\(FOAM_SITE_APPBIN\) \$env\(FOAM_APPBIN\) \$env\(WM_PROJECT_DIR\)/bin \$env\(WM_DIR\)'
+MAALI_MODULE_SET_LD_LIBRARY_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/gperftools-svn/lib \$env\(CGAL_ARCH_PATH\)/lib \$env\(FOAM_EXT_LIBBIN\)/\$env\(FOAM_MPI\) \$env\(FOAM_USER_LIBBIN\) \$env\(FOAM_SITE_LIBBIN\) \$env\(FOAM_LIBBIN\) \$env\(FOAM_EXT_LIBBIN\)'
+MAALI_MODULE_SET_LD_LIBRARY_PATH_APPEND='\$env\(FOAM_LIBBIN\)/dummy'
+# don't prenpend the path with stuff
+MAALI_MODULE_PREPEND_PATH=off
+MAALI_MODULE_PREPEND_LD_LIBRARY_PATH=off
+MAALI_MODULE_PREPEND_LD_LIBRARY_PATH_APPEND=off
+
+##############################################################################
+
+function maali_unpack {
+  maali_run "echo 'OpenFOAM will build in place'"
+}
+
+function maali_build {
+
+  # OpenFOAM builds in place
+  cd "$MAALI_INSTALL_DIR"
+  tar xzf $MAALI_SRC/OpenFOAM-$MAALI_TOOL_VERSION.tar.gz
+  tar xzf $MAALI_SRC/ThirdParty-$MAALI_TOOL_VERSION.tar.gz
+
+  # Set up the location of OpenFOAM's bashrc file
+  export FOAM_INST_DIR="$MAALI_INSTALL_DIR"
+  foamDotFile=$FOAM_INST_DIR/OpenFOAM-$MAALI_TOOL_VERSION/etc/bashrc
+
+  # Modifications to build on Zeus, and for Intel compilers
+  cd $FOAM_INST_DIR
+  if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
+     sed -i -e 's/export WM_COMPILER=Gcc/export WM_COMPILER=Icc/g' $foamDotFile
+     sed -i -e 's/gcc/icc/g' $WM_THIRD_PARTY_DIR/etc/wmakeFiles/scotch/Makefile.inc.i686_pc_linux2.shlib-OpenFOAM
+  fi
+  sed -i -e 's/boost_version=1_64_0/boost_version=boost-system/g' OpenFOAM-$MAALI_TOOL_VERSION/etc/config.sh/CGAL
+  sed -i -e 's,BOOST_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$boost_version,BOOST_ARCH_PATH=$BOOST_ROOT,g' OpenFOAM-$MAALI_TOOL_VERSION/etc/config.sh/CGAL
+
+  # Set up OpenFOAM environment
+  [ -f $foamDotFile ] && . $foamDotFile
+  export WM_NCOMPPROCS=12
+
+  # Build METIS before OpenFOAM
+  cd $WM_THIRD_PARTY_DIR
+  maali_run "cp $MAALI_SRC/metis-5.1.0.tar.gz ."
+  maali_run "tar xf metis-5.1.0.tar.gz"
+  maali_run "cp $MAALI_SRC/cmake-3.10.1.tar.gz ."
+  maali_run "tar xf cmake-3.10.1.tar.gz"
+  maali_run "rm metis-5.1.0.tar.gz cmake-3.10.1.tar.gz"
+
+  # Build OpenFOAM
+  cd $WM_PROJECT_DIR
+  maali_run "./Allwmake"
+
+  # Build ParaFOAM and utilities
+  #
+  # If building with Intel 17 compilers you'll need to use an updated version of CMake
+  # Just download and untar the source code in the ThirdParty directory and run
+  #
+  # makeCmake cmake-VERSION
+  #
+  # You can then pass that cmake install directory to the makeParaView command
+  cd $WM_THIRD_PARTY_DIR
+  export FC=mpif90
+  if [ "$MAALI_COMPILER_NAME" == "gcc" ]; then
+    maali_run "./makeParaView -mpi -qt -python -python-lib $PYTHON_DIR/lib/libpython$MAALI_PYTHON_LIB_VERSION.so"
+  elif [ "$MAALI_COMPILER_NAME" == "intel" ]; then
+    maali_run "./makeCmake cmake-3.10.1"
+    maali_run "./makeParaView -mpi -qt -python -python-lib $PYTHON_DIR/lib/libpython$MAALI_PYTHON_LIB_VERSION.so -cmake ./platforms/linux64Icc/cmake-3.10.1/bin/cmake"
+  fi
+  cd $FOAM_UTILITIES/postProcessing/graphics/PVReaders
+  . $foamDotFile
+  export PV_PLUGIN_PATH=$FOAM_LIBBIN/paraview-$ParaView_MAJOR
+  if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
+    export PATH=$WM_THIRD_PARTY_DIR/platforrms/${WM_ARCH}${WM_COMPILER}/cmake-3.10.1/bin:$PATH
+  fi
+  maali_run "./Allwclean"
+  maali_run "./Allwmake"
+
+  # Re-run make to finish the post-processing utilities that require a ParaView installation
+  cd $WM_PROJECT_DIR
+  maali_run "./Allwmake"
+
+  # fix permissions
+  maali_run "find $MAALI_INSTALL_DIR -perm 750 -exec chmod 755 {} \;"
+  maali_run "find $MAALI_INSTALL_DIR -perm 640 -exec chmod 644 {} \;"
+}
+
+##############################################################################

--- a/sles12sp3/openfoam.cyg
+++ b/sles12sp3/openfoam.cyg
@@ -3,11 +3,10 @@
 #
 # This is for the OpenFOAM foundation version
 ##############################################################################
-
 read -r -d '' MAALI_MODULE_WHATIS << EOF
 
-OpenFOAM is an open-source CFD package, providing solvers, visualisation tools,
-and pre- and post-processing utilities.
+OpenFOAM is an open-source CFD package, providing solvers, visualisation
+tools, and pre- and post-processing utilities.
 
 This module provides the OpenFOAM foundation version of OpenFOAM
 
@@ -16,7 +15,8 @@ For further information see http://openfoam.org
 EOF
 
 # specify which compilers we want to build the tool with
-MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_INTEL_COMPILERS"
+MAALI_TOOL_COMPILERS=$MAALI_DEFAULT_COMPILERS
+MAALI_TOOL_CPU_TARGET="sandybridge broadwell"
 
 # URL to download the source code from
 MAALI_URL="https://github.com/OpenFOAM/OpenFOAM-$MAALI_TOOL_MAJOR_VERSION.x/archive/version-$MAALI_TOOL_VERSION.tar.gz https://github.com/OpenFOAM/ThirdParty-$MAALI_TOOL_MAJOR_VERSION.x/archive/version-$MAALI_TOOL_VERSION.tar.gz https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.8.1/CGAL-4.8.1.tar.xz"
@@ -43,7 +43,7 @@ MAALI_MODULE_SET_WM_LDFLAGS='-m64'
 MAALI_MODULE_SET_FOAM_INST_DIR='$MAALI_APP_HOME'
 MAALI_MODULE_SET_WM_PROJECT='OpenFOAM'
 MAALI_MODULE_SET_WM_PROJECT_VERSION='$MAALI_TOOL_VERSION'
-MAALI_MODULE_SET_WM_COMPILER='\$env\(foam_COMPILER\)'
+MAALI_MODULE_SET_WM_COMPILER='os.getenv(foam_COMPILER)'
 MAALI_MODULE_SET_WM_COMPILER_TYPE=system
 MAALI_MODULE_SET_WM_ARCH_OPTION='64'
 MAALI_MODULE_SET_WM_PRECISION_OPTION='DP'
@@ -52,49 +52,50 @@ MAALI_MODULE_SET_WM_COMPILE_OPTION='Opt'
 MAALI_MODULE_SET_WM_MPLIB='SYSTEMOPENMPI'
 MAALI_MODULE_SET_WM_OSTYPE='POSIX'
 MAALI_MODULE_SET_FOAM_SIGFPE=''
-MAALI_MODULE_SET_WM_PROJECT_INST_DIR='\$env\(FOAM_INST_DIR\)'
-MAALI_MODULE_SET_WM_PROJECT_DIR='\$env\(WM_PROJECT_INST_DIR\)/\$env\(WM_PROJECT\)-\$env\(WM_PROJECT_VERSION\)'
-MAALI_MODULE_SET_WM_THIRD_PARTY_DIR='\$env\(WM_PROJECT_INST_DIR\)/ThirdParty-\$env\(WM_PROJECT_VERSION\)'
-MAALI_MODULE_SET_WM_PROJECT_USER_DIR='\$env\(MYGROUP\)/\$env\(WM_PROJECT\)/\$env\(USER\)-\$env\(WM_PROJECT_VERSION\)'
+MAALI_MODULE_SET_WM_PROJECT_INST_DIR='os.getenv(FOAM_INST_DIR)'
+MAALI_MODULE_SET_WM_PROJECT_DIR='os.getenv(WM_PROJECT_INST_DIR)/os.getenv(WM_PROJECT)-os.getenv(WM_PROJECT_VERSION)'
+MAALI_MODULE_SET_WM_THIRD_PARTY_DIR='os.getenv(WM_PROJECT_INST_DIR)/ThirdParty-os.getenv(WM_PROJECT_VERSION)'
+MAALI_MODULE_SET_WM_PROJECT_USER_DIR='os.getenv(MYGROUP)/os.getenv(WM_PROJECT)/os.getenv(USER)-os.getenv(WM_PROJECT_VERSION)'
 MAALI_MODULE_SET_FOAM_SETTINGS=''
 MAALI_MODULE_SET_WM_ARCH='linux64'
 MAALI_MODULE_SET_WM_COMPILER_LIB_ARCH='64'
 MAALI_MODULE_SET_WM_CC='mpicc'
 MAALI_MODULE_SET_WM_CXX='mpicxx'
-MAALI_MODULE_SET_FOAM_JOB_DIR='\$env\(WM_PROJECT_INST_DIR\)/jobControl'
-MAALI_MODULE_SET_WM_DIR='\$env\(WM_PROJECT_DIR\)/wmake'
+MAALI_MODULE_SET_FOAM_JOB_DIR='os.getenv(WM_PROJECT_INST_DIR)/jobControl'
+MAALI_MODULE_SET_WM_DIR='os.getenv(WM_PROJECT_DIR)/wmake'
 MAALI_MODULE_SET_WM_LINK_LANGUAGE='c++'
-MAALI_MODULE_SET_WM_LABEL_OPTION='Int\$env\(WM_LABEL_SIZE\)'
-MAALI_MODULE_SET_WM_OPTIONS='\$env\(WM_ARCH\)\$env\(WM_COMPILER\)\$env\(WM_PRECISION_OPTION\)\$env\(WM_LABEL_OPTION\)\$env\(WM_COMPILE_OPTION\)'
-MAALI_MODULE_SET_FOAM_APPBIN='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/bin'
-MAALI_MODULE_SET_FOAM_LIBBIN='\$env\(WM_PROJECT_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
-MAALI_MODULE_SET_FOAM_EXT_LIBBIN='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
-MAALI_MODULE_SET_FOAM_SITE_APPBIN='\$env\(WM_PROJECT_INST_DIR\)/site/\$env\(WM_PROJECT_VERSION\)/platforms/\$env\(WM_OPTIONS\)/bin'
-MAALI_MODULE_SET_FOAM_SITE_LIBBIN='\$env\(WM_PROJECT_INST_DIR\)/site/\$env\(WM_PROJECT_VERSION\)/platforms/\$env\(WM_OPTIONS\)/lib'
-MAALI_MODULE_SET_FOAM_USER_APPBIN='\$env\(WM_PROJECT_USER_DIR\)/platforms/\$env\(WM_OPTIONS\)/bin'
-MAALI_MODULE_SET_FOAM_USER_LIBBIN='\$env\(WM_PROJECT_USER_DIR\)/platforms/\$env\(WM_OPTIONS\)/lib'
-MAALI_MODULE_SET_FOAM_ETC='\$env\(WM_PROJECT_DIR\)/etc'
-MAALI_MODULE_SET_FOAM_APP='\$env\(WM_PROJECT_DIR\)/applications'
-MAALI_MODULE_SET_FOAM_SRC='\$env\(WM_PROJECT_DIR\)/src'
-MAALI_MODULE_SET_FOAM_TUTORIALS='\$env\(WM_PROJECT_DIR\)/tutorials'
-MAALI_MODULE_SET_FOAM_UTILITIES='\$env\(FOAM_APP\)/utilities'
-MAALI_MODULE_SET_FOAM_SOLVERS='\$env\(FOAM_APP\)/solvers'
-MAALI_MODULE_SET_FOAM_RUN='\$env\(WM_PROJECT_USER_DIR\)/run'
+MAALI_MODULE_SET_WM_LABEL_OPTION='"Int"..os.getenv(WM_LABEL_SIZE)'
+MAALI_MODULE_SET_WM_OPTIONS='os.getenv(WM_ARCH)os.getenv(WM_COMPILER)os.getenv(WM_PRECISION_OPTION)os.getenv(WM_LABEL_OPTION)os.getenv(WM_COMPILE_OPTION)'
+MAALI_MODULE_SET_FOAM_APPBIN='os.getenv(WM_PROJECT_DIR)/platforms/os.getenv(WM_OPTIONS)/bin'
+MAALI_MODULE_SET_FOAM_LIBBIN='os.getenv(WM_PROJECT_DIR)/platforms/os.getenv(WM_OPTIONS)/lib'
+MAALI_MODULE_SET_FOAM_EXT_LIBBIN='os.getenv(WM_THIRD_PARTY_DIR)/platforms/os.getenv(WM_OPTIONS)/lib'
+MAALI_MODULE_SET_FOAM_SITE_APPBIN='os.getenv(WM_PROJECT_INST_DIR)/site/os.getenv(WM_PROJECT_VERSION)/platforms/os.getenv(WM_OPTIONS)/bin'
+MAALI_MODULE_SET_FOAM_SITE_LIBBIN='os.getenv(WM_PROJECT_INST_DIR)/site/os.getenv(WM_PROJECT_VERSION)/platforms/os.getenv(WM_OPTIONS)/lib'
+MAALI_MODULE_SET_FOAM_USER_APPBIN='os.getenv(WM_PROJECT_USER_DIR)/platforms/os.getenv(WM_OPTIONS)/bin'
+MAALI_MODULE_SET_FOAM_USER_LIBBIN='os.getenv(WM_PROJECT_USER_DIR)/platforms/os.getenv(WM_OPTIONS)/lib'
+MAALI_MODULE_SET_FOAM_ETC='os.getenv(WM_PROJECT_DIR)/etc'
+MAALI_MODULE_SET_FOAM_APP='os.getenv(WM_PROJECT_DIR)/applications'
+MAALI_MODULE_SET_FOAM_SRC='os.getenv(WM_PROJECT_DIR)/src'
+MAALI_MODULE_SET_FOAM_TUTORIALS='os.getenv(WM_PROJECT_DIR)/tutorials'
+MAALI_MODULE_SET_FOAM_UTILITIES='os.getenv(FOAM_APP)/utilities'
+MAALI_MODULE_SET_FOAM_SOLVERS='os.getenv(FOAM_APP)/solvers'
+MAALI_MODULE_SET_FOAM_RUN='os.getenv(WM_PROJECT_USER_DIR)/run'
 MAALI_MODULE_SET_FOAM_MPI='openmpi-system'
-MAALI_MODULE_SET_MPI_ARCH_PATH='\$env\(MAALI_OPENMPI_HOME\)'
+MAALI_MODULE_SET_FOAM_FILEHANDLER='collated'
+MAALI_MODULE_SET_MPI_ARCH_PATH='os.getenv(MAALI_OPENMPI_HOME)'
 MAALI_MODULE_SET_MPI_BUFFER_SIZE='20000000'
 MAALI_MODULE_SET_ParaView_VERSION='5.4.0'
 MAALI_MODULE_SET_ParaView_MAJOR='5.4'
-MAALI_MODULE_SET_ParaView_DIR='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/ParaView-\$env\(ParaView_VERSION\)'
-MAALI_MODULE_SET_ParaView_LIB_DIR='\$env\(ParaView_DIR\)/lib/paraview-\$env\(ParaView_MAJOR\)'
-MAALI_MODULE_SET_ParaView_INCLUDE_DIR='\$env\(ParaView_DIR\)/include/paraview-\$env\(ParaView_MAJOR\)'
-MAALI_MODULE_SET_PV_PLUGIN_PATH='\$env\(FOAM_LIBBIN\)/paraview-\$env\(ParaView_MAJOR\)'
-MAALI_MODULE_SET_BOOST_ARCH_PATH='\$env\(MAALI_BOOST_HOME\)'
-MAALI_MODULE_SET_ParaView_DIR='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/ParaView-\$env\(ParaView_VERSION\)'
-MAALI_MODULE_SET_CGAL_ARCH_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)/$env\(WM_COMPILER\)/CGAL-4.8.1'
-MAALI_MODULE_SET_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/gperftools-svn/bin \$env\(ParaView_DIR\)/bin \$env\(FOAM_USER_APPBIN\) \$env\(FOAM_SITE_APPBIN\) \$env\(FOAM_APPBIN\) \$env\(WM_PROJECT_DIR\)/bin \$env\(WM_DIR\)'
-MAALI_MODULE_SET_LD_LIBRARY_PATH='\$env\(WM_THIRD_PARTY_DIR\)/platforms/\$env\(WM_ARCH\)\$env\(WM_COMPILER\)/gperftools-svn/lib \$env\(CGAL_ARCH_PATH\)/lib \$env\(FOAM_EXT_LIBBIN\)/\$env\(FOAM_MPI\) \$env\(FOAM_USER_LIBBIN\) \$env\(FOAM_SITE_LIBBIN\) \$env\(FOAM_LIBBIN\) \$env\(FOAM_EXT_LIBBIN\)'
-MAALI_MODULE_SET_LD_LIBRARY_PATH_APPEND='\$env\(FOAM_LIBBIN\)/dummy'
+MAALI_MODULE_SET_ParaView_DIR='os.getenv(WM_THIRD_PARTY_DIR)/platforms/os.getenv(WM_ARCH)os.getenv(WM_COMPILER)/ParaView-os.getenv(ParaView_VERSION)'
+MAALI_MODULE_SET_ParaView_LIB_DIR='os.getenv(ParaView_DIR)/lib/paraview-os.getenv(ParaView_MAJOR)'
+MAALI_MODULE_SET_ParaView_INCLUDE_DIR='os.getenv(ParaView_DIR)/include/paraview-os.getenv(ParaView_MAJOR)'
+MAALI_MODULE_SET_PV_PLUGIN_PATH='os.getenv(FOAM_LIBBIN)/paraview-os.getenv(ParaView_MAJOR)'
+MAALI_MODULE_SET_BOOST_ARCH_PATH='os.getenv(MAALI_BOOST_HOME)'
+MAALI_MODULE_SET_ParaView_DIR='os.getenv(WM_THIRD_PARTY_DIR)/platforms/os.getenv(WM_ARCH)os.getenv(WM_COMPILER)/ParaView-os.getenv(ParaView_VERSION)'
+MAALI_MODULE_SET_CGAL_ARCH_PATH='os.getenv(WM_THIRD_PARTY_DIR)/platforms/os.getenv(WM_ARCH)/$env(WM_COMPILER)/CGAL-4.8.1'
+MAALI_MODULE_SET_PATH='os.getenv(WM_THIRD_PARTY_DIR)/platforms/os.getenv(WM_ARCH)os.getenv(WM_COMPILER)/gperftools-svn/bin os.getenv(ParaView_DIR)/bin os.getenv(FOAM_USER_APPBIN) os.getenv(FOAM_SITE_APPBIN) os.getenv(FOAM_APPBIN) os.getenv(WM_PROJECT_DIR)/bin os.getenv(WM_DIR)'
+MAALI_MODULE_SET_LD_LIBRARY_PATH='os.getenv(WM_THIRD_PARTY_DIR)/platforms/os.getenv(WM_ARCH)os.getenv(WM_COMPILER)/gperftools-svn/lib os.getenv(CGAL_ARCH_PATH)/lib os.getenv(FOAM_EXT_LIBBIN)/os.getenv(FOAM_MPI) os.getenv(FOAM_USER_LIBBIN) os.getenv(FOAM_SITE_LIBBIN) os.getenv(FOAM_LIBBIN) os.getenv(FOAM_EXT_LIBBIN)'
+MAALI_MODULE_SET_LD_LIBRARY_PATH_APPEND='os.getenv(FOAM_LIBBIN)/dummy'
 # don't prenpend the path with stuff
 MAALI_MODULE_PREPEND_PATH=off
 MAALI_MODULE_PREPEND_LD_LIBRARY_PATH=off
@@ -123,7 +124,7 @@ function maali_build {
   cd $FOAM_INST_DIR
   if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
      sed -i -e 's/export WM_COMPILER=Gcc/export WM_COMPILER=Icc/g' $foamDotFile
-     sed -i -e 's/gcc/icc/g' $WM_THIRD_PARTY_DIR/etc/wmakeFiles/scotch/Makefile.inc.i686_pc_linux2.shlib-OpenFOAM
+     sed -i -e 's/gcc/icc/g' $MAALI_INSTALL_DIR/ThirdParty-$MAALI_TOOL_VERSION/etc/wmakeFiles/scotch/Makefile.inc.i686_pc_linux2.shlib-OpenFOAM
   fi
   sed -i -e 's/cgal_version=cgal-system/#cgal_version=cgal-system/g' OpenFOAM-$MAALI_TOOL_VERSION/etc/config.sh/CGAL
   sed -i -e 's/#cgal_version=CGAL-4.8.1/cgal_version=CGAL-4.8.1/g' OpenFOAM-$MAALI_TOOL_VERSION/etc/config.sh/CGAL


### PR DESCRIPTION
Intel compiler support added
ParaView build fixed
Collated file IO added to module

This still needs a maali fix to deal with the quotes and os.genv
conversion.  As it stands, this will compile openfoam and openfoam+
but it will require hand-modification of the generated modulefile