### PR TITLE
removed reference to nonexistant glib module

### DIFF
--- a/cle60up05/gerris.cyg
+++ b/cle60up05/gerris.cyg
@@ -1,0 +1,76 @@
+##############################################################################
+# maali cygnet file for gerris  
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+Gerris is a Free Software program for the solution of the partial differential equations describing fluid flow.
+
+For further information see http://gfs.sourceforge.net/wiki/index.php/Main_Page
+
+EOF
+
+
+# specify which PrgEnv we want to build the tool with
+MAALI_TOOL_CRAY_PRGENV="$MAALI_DEFAULT_CRAY_GCC_PRGENV $MAALI_DEFAULT_CRAY_INTEL_PRGENV"
+
+# specify which cpus to target
+MAALI_TOOL_CRAY_CPU_TARGET="$MAALI_DEFAULT_CRAY_PES"
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+
+# URL to download the source code from
+MAALI_URL="http://gerris.dalembert.upmc.fr/gerris/$MAALI_TOOL_NAME-snapshot.tar.gz"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-snapshot.tar.gz"
+
+# tool pre-requisites modules needed to install this new tool/package
+MAALI_TOOL_PREREQ="$MAALI_DEFAULT_MPI cray-fftw cray-netcdf gsl gts cray-tpsl"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-snapshot-$MAALI_TOOL_VERSION"
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_MANPATH=1
+MAALI_MODULE_SET_PKG_CONFIG_PATH=1
+
+##############################################################################
+
+function maali_build {
+# add additional configure options
+  if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
+    MAALI_TOOL_CONFIGURE='--host=x86_64-unknown-linux-gnu --disable-gsltest --enable-mpi --with-pic --with-mpicc=$MAALI_TOOL_BUILD_DIR/mpicc CC=cc CXX=CC CFLAGS=-openmp LDFLAGS=-dynamic'
+  elif [ "$MAALI_COMPILER_NAME" == "gcc" ]; then
+    MAALI_TOOL_CONFIGURE='--host=x86_64-unknown-linux-gnu --disable-gsltest --enable-mpi --with-pic --with-mpicc=$MAALI_TOOL_BUILD_DIR/mpicc CC=cc CXX=CC CFLAGS=-fopenmp LDFLAGS=-dynamic'
+  fi
+
+  # Work around Cray not setting up pkg-config for user applications.
+  target="PE_FFTW_TARGET_${CRAY_CPU_TARGET}"
+  CRAY_FFTW_PKGCONFIG_PATH=${PE_FFTW_VOLATILE_PKGCONFIG_PATH/@PE_FFTW_TARGET@/${!target}}
+  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${CRAY_FFTW_PKGCONFIG_PATH}
+
+  # allows late evaluation
+  MAALI_TOOL_CONFIGURE_EVAL=`eval echo "$MAALI_TOOL_CONFIGURE"`
+
+  # Make a wrapper called mpicc, because that's how they check for MPI.
+  cd "$MAALI_TOOL_BUILD_DIR"
+cat <<EOF > mpicc
+#!/bin/bash
+cc \$@
+EOF
+chmod +x mpicc
+  maali_run "./configure --prefix=$MAALI_INSTALL_DIR $MAALI_TOOL_CONFIGURE_EVAL"
+
+  maali_run 'sed -i -e "s/--mode=link \$(CC)/--mode=link \$(CC) -dynamic/gi" doc/examples/Makefile'
+  maali_run 'sed -i -e "s/--mode=link \$(CC)/--mode=link \$(CC) -dynamic/gi" doc/Makefile'
+
+  maali_run 'make'
+  maali_run "make install"
+}
+
+##############################################################################

--- a/cle60up05/gts.cyg
+++ b/cle60up05/gts.cyg
@@ -34,16 +34,16 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-snapshot.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-snapshot-121130"
 
 # type of tool (eg. apps, devel, python, etc.)
-MAALI_TOOL_TYPE="devel"
+MAALI_TOOL_TYPE="apps"
 
 # tool pre-requisites modules needed to install this new tool/package
-#MAALI_TOOL_PREREQ="glib"
+MAALI_TOOL_PREREQ=""
 
 # add additional configure options
 MAALI_TOOL_CONFIGURE='--enable-shared --enable-static --with-pic CC=cc CXX=CC LDFLAGS=-dynamic'
 
 # Don't use haswell module, since --host option does not work for cross-compile.
-#MAALI_EXTRA_CRAY="craype-sandybridge"
+MAALI_EXTRA_CRAY="craype-sandybridge"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1


### PR DESCRIPTION
Removed reference to glib module. Sytem glib can now be used for GTS and Gerris builds.