### PR TITLE
h5py now only uses the default system gcc (via python), rather than m…

### DIFF
--- a/cle60up05/h5py.cyg
+++ b/cle60up05/h5py.cyg
@@ -23,7 +23,7 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME_ORIG-$MAALI_TOOL_VERSION"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ="PrgEnv-gnu/6.0.4 gcc/4.9.3 numpy/1.13.3 six/1.11.0"
+MAALI_TOOL_PREREQ="numpy/1.13.3 six/1.11.0"
 
 # tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
 MAALI_TOOL_BUILD_PREREQ="setuptools/38.2.1 cython/0.27.3 cray-hdf5/1.10.1.1"


### PR DESCRIPTION
…anually selecting one.