### PR TITLE
Adding munlink to cygnetfile for Pawseytools

### DIFF
--- a/cle60up05/pawseytools.cyg
+++ b/cle60up05/pawseytools.cyg
@@ -56,7 +56,7 @@ function maali_build {
     maali_run "install -m 755 $file $MAALI_INSTALL_DIR/bin/"
   done
 
-  maali_run "cc -o munlink munlink.c"
+  maali_run "gcc -o $MAALI_INSTALL_DIR/bin/munlink munlink.c"
 
   # version dependent
   sed -i -e 's/PAWSEY_TOOLS_VERSION/'$MAALI_TOOL_VERSION'/g' $MAALI_INSTALL_DIR/bin/startServer

--- a/cle60up05/pawseytools.cyg
+++ b/cle60up05/pawseytools.cyg
@@ -56,6 +56,8 @@ function maali_build {
     maali_run "install -m 755 $file $MAALI_INSTALL_DIR/bin/"
   done
 
+  maali_run "cc -o munlink munlink.c"
+
   # version dependent
   sed -i -e 's/PAWSEY_TOOLS_VERSION/'$MAALI_TOOL_VERSION'/g' $MAALI_INSTALL_DIR/bin/startServer
 }


### PR DESCRIPTION
Adding munlink to shared tools area. This does require a compile of munlink.c but it doesn't have any prereqs apart from system include files and is only 32 lines of source.