### PR TITLE
added support for latest version and python libraries in Boost

### DIFF
--- a/sles12sp3/boost.cyg
+++ b/sles12sp3/boost.cyg
@@ -15,9 +15,11 @@ For further information see http://www.boost.org/
 
 EOF
 
+# Request only the latest GNU and Intel compilers to be used
+MAALI_TOOL_COMPILERS="gcc/5.5.0 gcc/7.2.0 intel/17.0.5"
 
-# specify which compilers we want to build the tool with
-MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+# Only build Basilisk for the Sandybridge and Broadwell CPUs
+MAALI_TOOL_CPU_TARGET="sandybridge broadwell"
 
 # needed  for this URL
 MAALI_BOOST_VERSION=`echo $MAALI_TOOL_VERSION| sed -e 's/\./_/g'`
@@ -35,7 +37,7 @@ MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/"$MAALI_TOOL_NAME"_"$MAALI_BOOST_VERSION
 MAALI_TOOL_TYPE="devel"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ=""
+MAALI_TOOL_PREREQ="python"
 
 # for auto-building module files
 MAALI_MODULE_SET_LD_LIBRARY_PATH=1
@@ -49,15 +51,32 @@ MAALI_MODULE_SET_BOOST_ROOT='$MAALI_APP_HOME'
 function maali_build {
 
   cd "$MAALI_TOOL_BUILD_DIR"
-  if [ "$MAALI_COMPILER_NAME" == "intel" ]; then
-    maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR --without-libraries=python --with-toolset=intel-linux"
+
+  # Intel-compiler specifics
+  if [ "$MAALI_COMPILER_NAME" == "intel"* ]; then
+
+  if [ "$MAALI_TOOL_VERSION" == "1.66.0" ]; then
+    maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR --with-toolset=intel"
+    maali_run "./b2 -j8 install toolset=intel --prefix=$MAALI_INSTALL_DIR"
+  else
+    maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR --with-toolset=intel-linux"
     maali_run "./bjam -j$MAALI_CORES toolset=intel release"
+    maali_run "./bjam install --prefix=$MAALI_INSTALL_DIR"
+  fi
+
+  # GNU compiler specifics
+  else
+
+  if [ "$MAALI_TOOL_VERSION" == "1.66.0" ]; then
+    maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR --with-toolset=gcc"
+    maali_run "./b2 -j8 install toolset=gcc --prefix=$MAALI_INSTALL_DIR -j$MAALI_CORES"
   else
     maali_run "./bootstrap.sh --prefix=$MAALI_INSTALL_DIR --without-libraries=python"
     maali_run "./bjam -j$MAALI_CORES toolset=gcc release"
+    maali_run "./bjam install --prefix=$MAALI_INSTALL_DIR"
   fi
 
-  maali_run "./bjam install --prefix=$MAALI_INSTALL_DIR"
+  fi
 
   if [ "$MAALI_TOOL_VERSION" == "1.64.0" ]; then
     sed -i -e 's;#include <boost/serialization/array.hpp>;#include <boost/serialization/array_wrapper.hpp>;g;' $MAALI_INSTALL_DIR/include/boost/numeric/ublas/matrix.hpp

--- a/sles12sp3/hdf5-parallel.cyg
+++ b/sles12sp3/hdf5-parallel.cyg
@@ -1,0 +1,51 @@
+##############################################################################
+# maali cygnet file for hdf5-parallel
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+HDF5 is a data model, library, and file format for storing and managing data.
+It supports an unlimited variety of datatypes, and is designed for flexible and
+efficient I/O and for high volume and complex data. HDF5 is portable and is
+extensible, allowing applications to evolve in their use of HDF5. The HDF5
+Technology suite includes tools and applications for managing, manipulating,
+viewing, and analyzing data in the HDF5 format.
+
+For further information see https://www.hdfgroup.org/hdf5/
+
+EOF
+
+# Only build Basilisk for the Sandybridge and Broadwell CPUs
+MAALI_TOOL_CPU_TARGET="sandybridge broadwell"
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
+
+# URL to download the source code from
+MAALI_URL="https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$MAALI_TOOL_MAJOR_MINOR_VERSION/hdf5-$MAALI_TOOL_VERSION/src/hdf5-$MAALI_TOOL_VERSION.tar.bz2"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/hdf5-$MAALI_TOOL_VERSION.tar.bz2"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/hdf5-$MAALI_TOOL_VERSION"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# tool pre-requisites
+#zlib >= 1.2.8
+MAALI_TOOL_PREREQ="$MAALI_DEFAULT_MPI"
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE='--enable-parallel --enable-fortran CC=mpicc FC=mpif90'
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_MANPATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_FPATH=1
+MAALI_MODULE_SET_FCPATH=1
+MAALI_MODULE_SET_HDF5_DIR='$MAALI_APP_HOME'
+


### PR DESCRIPTION
Support for Version 1.66.0 added which uses new b2 install tool.  Support for Python libraries in Boost also enabled.