### PR TITLE
added casacore

### DIFF
--- a/sles12sp3/casacore.cyg
+++ b/sles12sp3/casacore.cyg
@@ -1,0 +1,51 @@
+##############################################################################
+# maali cygnet file for casacore
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+The casacore package contains the core libraries of the old AIPS++/CASA
+package. This split was made to get a better separation of core libraries and
+applications. CASA is now built on top of casacore.
+
+For further information see http://casacore.github.io/casacore/
+
+EOF
+
+# specify which compilers we want to build the tool with
+MAALI_TOOL_COMPILERS="gcc/4.8.5 gcc/5.5.0 gcc/7.2.0"
+
+# specify te CPU types to be built for
+MAALI_TOOL_CPU_TARGET="sandybridge broadwell"
+
+# URL to download the source code from
+if (( $(bc <<< "${MAALI_TOOL_MAJOR_MINOR_VERSION} < 2.0") )); then
+MAALI_URL="ftp://ftp.atnf.csiro.au/pub/software/$MAALI_TOOL_NAME/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.bz2"
+elif (( $(bc <<< "${MAALI_TOOL_MAJOR_MINOR_VERSION} >= 2.0") )); then
+MAALI_URL="https://github.com/${MAALI_TOOL_NAME}/${MAALI_TOOL_NAME}/archive/v${MAALI_TOOL_VERSION}.tar.gz"
+fi
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.bz2"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="apps"
+
+# tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
+MAALI_TOOL_BUILD_PREREQ=""
+
+# tool pre-requisites 
+MAALI_TOOL_PREREQ="python openmpi cfitsio wcslib hdf5-parallel fftw boost/1.66.0 numpy lapack"
+
+# add additional configure options
+MAALI_CMAKE_TOOL=1
+MAALI_TOOL_CONFIGURE='-DCMAKE_BUILD_TYPE=RELEASE -DUSE_HDF5=ON -DUSE_FFTW3=ON -DUSE_OPENMP=OFF -DBLAS_LIBRARIES=${MAALI_LAPACK_HOME}/lib64/libblas.so -DLAPACK_LIBRARIES=${MAALI_LAPACK_HOME}/lib64/liblapack.so -DCFITSIO_ROOT_DIR=${MAALI_CFITSIO_HOME} -DWCSLIB_ROOT_DIR=${MAALI_WCSLIB_HOME} -DHDF5_ROOT_DIR=${HDF5_DIR} -DFFTW3F_THREADS_LIBRARY=${FFTW_LIB}/libfftw3f_threads.so -DFFTW3_THREADS_LIBRARY=${FFTW_LIB}/libfftw3_threads.so -DFFTW3F_LIBRARY=${FFTW_LIB}/libfftw3f.so -DFFTW3_LIBRARY=${FFTW_LIB}/libfftw3.so -DFFTW3_INCLUDE_DIR=${FFTW_INCLUDE} -DDATA_DIR=/ivec/cle52/Casacore_data/data -DCMAKE_EXE_LINKER_FLAGS=-lcurl '
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_CASACORE_ROOT='$MAALI_APP_HOME'
+


### PR DESCRIPTION
Added support for Casacore. Tested the latest version (2.4.1) using parallel HDF5 and rebuilt Boost 1.66.0 with Python library support enabled.