### PR TITLE
removed gcc/4.8.5 support for casacore

### DIFF
--- a/sles12sp3/casacore.cyg
+++ b/sles12sp3/casacore.cyg
@@ -13,7 +13,7 @@ For further information see http://casacore.github.io/casacore/
 EOF
 
 # specify which compilers we want to build the tool with
-MAALI_TOOL_COMPILERS="gcc/4.8.5 gcc/5.5.0 gcc/7.2.0"
+MAALI_TOOL_COMPILERS="gcc/5.5.0 gcc/7.2.0"
 
 # specify te CPU types to be built for
 MAALI_TOOL_CPU_TARGET="sandybridge broadwell"


### PR DESCRIPTION
Removed gcc/4.8.5 support in casacore as the boost library required does not have support for that compiler version.