### PR TITLE
Marco: mods to cle60up05/lammps.cyg to build recent versions

### DIFF
--- a/cle60up05/lammps.cyg
+++ b/cle60up05/lammps.cyg
@@ -18,10 +18,10 @@ MAALI_TOOL_CRAY_CPU_TARGET="$MAALI_DEFAULT_CRAY_PES"
 MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_COMPILERS"
 
 # URL to download the source code from 
-MAALI_URL="http://lammps.sandia.gov/tars/${MAALI_TOOL_NAME}-stable.tar.gz"
+MAALI_URL="http://lammps.sandia.gov/tars/${MAALI_TOOL_NAME}-${MAALI_TOOL_VERSION}.tar.gz"
 
 # location we are downloading the source code to
-MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-stable.tar.gz" 
+MAALI_DST="$MAALI_SRC/${MAALI_TOOL_NAME}-${MAALI_TOOL_VERSION}.tar.gz" 
 
 # where the unpacked source code is located
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
@@ -129,19 +129,19 @@ function maali_build {
         make -f Makefile.h5cc
 
 #to build MSCG
-	cd "${MAALI_INSTALL_DIR}/lib/mscg"
-	maali_run "git clone https://github.com/uchicago-voth/MSCG-release.git"
-	mv MSCG-release/* .
-	cd "${MAALI_INSTALL_DIR}/lib/mscg/src"
-	sed -i 's/\-lgsl \-lgslcblas/\$\(MAALI\_GSL\_HOME\)\/lib \-lgsl \-lgslcblas/g' ../Makefile.mpi
-	sed -i 's/mpicc/cc/g' ../Makefile.mpi
-	sed -i 's/-O2/-O2 -std=c++11/g' ../Makefile.mpi
-	make -f ../Makefile.mpi libmscg.a
-	cd "${MAALI_INSTALL_DIR}/lib/mscg"
-	sed -i 's/\-lgsl \-lgslcblas/\-L \$\(MAALI\_GSL\_HOME\)\/lib \-lgsl \-lgslcblas/g' Makefile.lammps.mpi 
-	cp Makefile.lammps.mpi Makefile.lammps
-	ln -s src includelink
-	ln -s src liblink
+#	cd "${MAALI_INSTALL_DIR}/lib/mscg"
+#	maali_run "git clone https://github.com/uchicago-voth/MSCG-release.git"
+#	mv MSCG-release/* .
+#	cd "${MAALI_INSTALL_DIR}/lib/mscg/src"
+#	sed -i 's/\-lgsl \-lgslcblas/\$\(MAALI\_GSL\_HOME\)\/lib \-lgsl \-lgslcblas/g' ../Makefile.mpi
+#	sed -i 's/mpicc/cc/g' ../Makefile.mpi
+#	sed -i 's/-O2/-O2 -std=c++11/g' ../Makefile.mpi
+#	make -f ../Makefile.mpi libmscg.a
+#	cd "${MAALI_INSTALL_DIR}/lib/mscg"
+#	sed -i 's/\-lgsl \-lgslcblas/\-L \$\(MAALI\_GSL\_HOME\)\/lib \-lgsl \-lgslcblas/g' Makefile.lammps.mpi 
+#	cp Makefile.lammps.mpi Makefile.lammps
+#	ln -s src includelink
+#	ln -s src liblink
 
         cd "$MAALI_INSTALL_DIR/src"
   
@@ -150,6 +150,8 @@ function maali_build {
         maali_run "make no-omp"
         maali_run "make no-kim"
         maali_run "make no-kokkos"
+        maali_run "make no-latte"
+        maali_run "make no-mscg"
         maali_run "make no-user-cuda"
         maali_run "make no-user-intel"
 	if [ "$MAALI_COMPILER_NAME" == "intel" ]; then


### PR DESCRIPTION
1- made MAALI_URL and MAALI_DST able to deal with different versions (not only the latest)
2- disabled compilation of package mscg : there is a compile time error likely caused by bugs in the code ; I am not investigating it until users need it
3- disabled compilation of new package latte : requires additional build instructions, not investigating it until users need it