### PR TITLE
libconfig now installs properly. cuFFS support added

### DIFF
--- a/sles12sp3/cuffs.cyg
+++ b/sles12sp3/cuffs.cyg
@@ -1,0 +1,59 @@
+##############################################################################
+# maali cygnet file for cuFFS 
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+CUDA-accelerated Fast Faraday Synthesis code.
+
+For further information see https://github.com/sarrvesh/cuFFS
+
+EOF
+
+# specify which compilers we want to build the tool with. We specify only compilers that work with CUDA build
+MAALI_TOOL_COMPILERS="gcc/5.5.0"
+
+# specify te CPU types to be built for
+MAALI_TOOL_CPU_TARGET="sandybridge broadwell"
+
+# URL to download the source code from
+MAALI_URL="https://github.com/SpiderMonkey1975/cuFFS/archive/v$MAALI_TOOL_MAJOR_MINOR_VERSION.tar.gz"
+
+# location we are downloading the source code to
+MAALI_DST="$MAALI_SRC/cuFFS-$MAALI_TOOL_MAJOR_MINOR_VERSION.tar.gz"
+
+# where the unpacked source code is located
+MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/cuFFS-$MAALI_TOOL_MAJOR_MINOR_VERSION"
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# tool pre-requisites modules needed to install this new tool/package
+MAALI_TOOL_PREREQ="cuda cfitsio libconfig hdf5"
+
+# add additional configure options
+MAALI_TOOL_CONFIGURE=""
+
+# for auto-building module files
+MAALI_MODULE_SET_PATH=1
+MAALI_MODULE_SET_LD_LIBRARY_PATH=1
+MAALI_MODULE_SET_PKG_CONFIG_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_MANPATH=1
+
+
+##############################################################################
+
+function maali_build {
+
+# run make
+  cd "$MAALI_TOOL_BUILD_DIR/src"
+  maali_run "make"
+
+# copy executable to install directory
+  cd "$MAALI_INSTALL_DIR"
+  maali_run "mkdir bin"
+  cd "$MAALI_INSTALL_DIR/bin"
+  maali_run "cp $MAALI_TOOL_BUILD_DIR/src/rmsythesis ."
+
+}

--- a/sles12sp3/libconfig.cyg
+++ b/sles12sp3/libconfig.cyg
@@ -12,11 +12,15 @@ For further information see http://www.hyperrealm.com/libconfig/
 
 EOF
 
-# specify which compilers we want to build the tool with
-MAALI_TOOL_COMPILERS="gcc/5.5.0 gcc/7.2.0"
+# specify which compilers we want to build the tool with. We specify only compilers that work with CUDA build
+MAALI_TOOL_COMPILERS="gcc/5.5.0"
+
+# specify te CPU types to be built for
+MAALI_TOOL_CPU_TARGET="sandybridge broadwell"
 
 # URL to download the source code from
-MAALI_URL="https://github.com/hyperrealm/$MAALI_TOOL_NAME/archive/v${MAALI_TOOL_VERSION}.tar.gz"
+MAALI_URL="https://hyperrealm.github.io/libconfig/dist/libconfig-${MAALI_TOOL_VERSION}.tar.gz"
+#MAALI_URL="https://github.com/hyperrealm/libconfig/archive/v${MAALI_TOOL_VERSION}.tar.gz"
 
 # location we are downloading the source code to
 MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
@@ -30,12 +34,31 @@ MAALI_TOOL_TYPE="devel"
 # tool pre-requisites modules needed to install this new tool/package
 MAALI_TOOL_PREREQ=""
 
-# tool build pre-requisites - not added to the module, only needed for building (loaded after MAALI_TOOL_PREREQ)
-MAALI_TOOL_BUILD_PREREQ="cmake/3.5.2"
+# add additional configure options
+#MAALI_TOOL_CONFIGURE='--with-gnu-ld'
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
 MAALI_MODULE_SET_LD_LIBRARY_PATH=1
 MAALI_MODULE_SET_PKG_CONFIG_PATH=1
+MAALI_MODULE_SET_CPATH=1
+MAALI_MODULE_SET_MANPATH=1
+
 
 ##############################################################################
+
+#function maali_build {
+
+# generate configure script 
+#  cd "$MAALI_TOOL_BUILD_DIR"
+#  maali_run "aclocal"
+#  maali_run "autoconf"
+#  maali_run "automake --add-missing --foreign"
+
+# run configure script and then build 
+#  maali_run "./configure --prefix=$MAALI_INSTALL_DIR"
+#  maali_run "make"
+#  maali_run "make install"
+
+#}
+


### PR DESCRIPTION
cuFFS support added due to an user support request.  lidconfig.cyg was updated to work with the latest version (1.7.2)