### PR TITLE
removed paramiko and pycrypto dependencies on bazaar install

### DIFF
--- a/cle60up05/bzr.cyg
+++ b/cle60up05/bzr.cyg
@@ -27,7 +27,8 @@ MAALI_DST="$MAALI_SRC/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION.tar.gz"
 MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ="paramiko/2.4.0 pycrypto/2.6.1"
+MAALI_TOOL_PREREQ="setuptools cython"
+#MAALI_TOOL_PREREQ="paramiko/2.4.0 pycrypto/2.6.1"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1


### PR DESCRIPTION
Paramiko and PyCrypto are not installed on Magnus and do not have working Maali cygnet files.  However, Bazaar works fine without them.